### PR TITLE
Fix typo in cycle editor message

### DIFF
--- a/core/i18n/resources/en.js
+++ b/core/i18n/resources/en.js
@@ -143,7 +143,7 @@ module.exports = {
     surveyDeleted: 'Survey {{surveyName}} has been deleted',
     surveyInfo: {
       confirmPublish: `Do you want to publish this survey? Some operation won't be allowed afterwards.`,
-      confirmDeleteCycle:`Are you sure you want to delete the cycle {{cycle}}?n\n$t(common.cantUndoWarning)`,
+      confirmDeleteCycle:`Are you sure you want to delete the cycle {{cycle}}?\n\n$t(common.cantUndoWarning)`,
       editInfo: 'Edit info',
       publish: 'Publish',
       viewInfo: 'View info',

--- a/webapp/loggedin/modules/designer/surveyInfo/components/cyclesEditor.js
+++ b/webapp/loggedin/modules/designer/surveyInfo/components/cyclesEditor.js
@@ -53,10 +53,12 @@ const CycleEditor = props => {
     onChange, onDelete
   } = props
 
+  const stepNum = Number(step) + 1
+
   return (
     <div key={step} className="cycle">
       <div className="step">
-        {Number(step) + 1} -
+        {stepNum}
       </div>
       <DateContainer
         date={SurveyCycle.getDateStart(cycle)}
@@ -79,7 +81,7 @@ const CycleEditor = props => {
       {
         canDelete &&
         <button className="btn-s btn-transparent btn-delete"
-                onClick={() => window.confirm(i18n.t('homeView.surveyInfo.confirmDeleteCycle', { cycle: step + 1 }))
+                onClick={() => window.confirm(i18n.t('homeView.surveyInfo.confirmDeleteCycle', { cycle: stepNum }))
                   ? onDelete(step)
                   : null
                 }>


### PR DESCRIPTION
Should be straightforward. I'm mainly just wondering if this could be a systematic issue.
`cycle` (`step`) is stored as a string, but it's really a number, leading to these sorts of issues.

The error message would previously be like `"5" + 1` -> `cycle 51`.