### PR TITLE
Make user menu the topmost element

### DIFF
--- a/webapp/loggedin/appHeader/components/userPopupMenu.scss
+++ b/webapp/loggedin/appHeader/components/userPopupMenu.scss
@@ -6,7 +6,7 @@
   top: $headerHeight - 1px;
   border-bottom: 1px solid $greyBorder;
   border-left: 1px solid $greyBorder;
-  z-index: $zIndex900UserMenu;
+  z-index: $zIndex180UserMenu;
   background-color: white;
   display: grid;
   padding: 20px 10px 10px;

--- a/webapp/loggedin/appHeader/components/userPopupMenu.scss
+++ b/webapp/loggedin/appHeader/components/userPopupMenu.scss
@@ -6,7 +6,7 @@
   top: $headerHeight - 1px;
   border-bottom: 1px solid $greyBorder;
   border-left: 1px solid $greyBorder;
-  z-index: $zIndex10TopOfApp;
+  z-index: $zIndex900UserMenu;
   background-color: white;
   display: grid;
   padding: 20px 10px 10px;

--- a/webapp/style/_vars.scss
+++ b/webapp/style/_vars.scss
@@ -33,6 +33,7 @@ $zIndex20Dropdown: 20;
 $zIndex80AppNotification: 80;
 $zIndex90AppError: 90;
 $zIndex190AppLoader: 190;
+$zIndex900UserMenu: 900;
 
 $shadow1: 0 0 4px rgba($black, .2);
 $shadow2: 0 0 8px rgba($black, .2);

--- a/webapp/style/_vars.scss
+++ b/webapp/style/_vars.scss
@@ -32,8 +32,9 @@ $zIndex19AppModal: 19;
 $zIndex20Dropdown: 20;
 $zIndex80AppNotification: 80;
 $zIndex90AppError: 90;
+$zIndex180UserMenu: 180;
+/* Policy: everything is below app loader to stop user action */
 $zIndex190AppLoader: 190;
-$zIndex900UserMenu: 900;
 
 $shadow1: 0 0 4px rgba($black, .2);
 $shadow2: 0 0 8px rgba($black, .2);


### PR DESCRIPTION
The user menu should have the highest precedence since it has to be explicitly toggled on.

Currently it gets hidden behind some elements (e.g. the nodeDef editor)
