### PR TITLE
addNodeDefPanel.js: Actually invoke isRenderTable

### DIFF
--- a/webapp/loggedin/surveyViews/surveyForm/components/addNodeDefPanel.js
+++ b/webapp/loggedin/surveyViews/surveyForm/components/addNodeDefPanel.js
@@ -28,7 +28,7 @@ const AddNodeDefButtons = props => {
             const nodeDefProps = NodeDefUIProps.getDefaultPropsByType(type, surveyCycleKey)
 
             // cannot add entities when entity is rendered as table
-            const disabled = type === NodeDef.nodeDefType.entity && NodeDefLayout.isRenderTable(nodeDef)
+            const disabled = type === NodeDef.nodeDefType.entity && NodeDefLayout.isRenderTable(surveyCycleKey)(nodeDef)
 
             return (
               <button key={type}


### PR DESCRIPTION
NodeDefLayout.isRenderTable is typed like
`isRenderTable: cycle => nodeDef => boolean`

Previously `disabled` was sometimes a function rather than a boolean.