### PR TITLE
Test-created survey: Add warning labels not to use

### DIFF
--- a/test/it/006activityLogTest.js
+++ b/test/it/006activityLogTest.js
@@ -18,8 +18,8 @@ describe('Activity Log Test', async () => {
 
   it('Activity Log on Survey Creation', async () => {
     const surveyParam = {
-      name: 'DO NOT USE! test_survey_' + uuidv4(),
-      label: 'Test Survey',
+      name: 'do_not_use__test_survey_' + uuidv4(),
+      label: 'DO NOT USE! Test Survey',
       languages: ['en']
     }
     const survey = await SurveyManager.createSurvey(getContextUser(), surveyParam)

--- a/test/it/006activityLogTest.js
+++ b/test/it/006activityLogTest.js
@@ -18,7 +18,7 @@ describe('Activity Log Test', async () => {
 
   it('Activity Log on Survey Creation', async () => {
     const surveyParam = {
-      name: 'test_survey_' + uuidv4(),
+      name: 'DO NOT USE! test_survey_' + uuidv4(),
       label: 'Test Survey',
       languages: ['en']
     }

--- a/test/it/surveyTests/surveyTest.js
+++ b/test/it/surveyTests/surveyTest.js
@@ -6,8 +6,8 @@ const SurveyManager = require('@server/modules/survey/manager/surveyManager')
 const Survey = require('@core/survey/survey')
 
 const testSurvey = {
-  name: 'DO NOT USE! test_survey_' + uuidv4(),
-  label: 'Test Survey',
+  name: 'do_not_use__test_survey_' + uuidv4(),
+  label: 'DO NOT USE! Test Survey',
   languages: ['en']
 }
 

--- a/test/it/surveyTests/surveyTest.js
+++ b/test/it/surveyTests/surveyTest.js
@@ -6,7 +6,7 @@ const SurveyManager = require('@server/modules/survey/manager/surveyManager')
 const Survey = require('@core/survey/survey')
 
 const testSurvey = {
-  name: 'test_survey_' + uuidv4(),
+  name: 'DO NOT USE! test_survey_' + uuidv4(),
   label: 'Test Survey',
   languages: ['en']
 }

--- a/test/it/utils/surveyBuilder.js
+++ b/test/it/utils/surveyBuilder.js
@@ -131,8 +131,8 @@ class SurveyBuilder {
 
   constructor (user, rootDefBuilder) {
     this.user = user
-    this.name = `DO NOT USE! test_${new Date().getTime()}`
-    this.label = 'Test'
+    this.name = `do_not_use__test_${new Date().getTime()}`
+    this.label = 'DO NOT USE! Test'
     this.lang = 'en'
     this.rootDefBuilder = rootDefBuilder
   }

--- a/test/it/utils/surveyBuilder.js
+++ b/test/it/utils/surveyBuilder.js
@@ -131,7 +131,7 @@ class SurveyBuilder {
 
   constructor (user, rootDefBuilder) {
     this.user = user
-    this.name = `test_${new Date().getTime()}`
+    this.name = `DO NOT USE! test_${new Date().getTime()}`
     this.label = 'Test'
     this.lang = 'en'
     this.rootDefBuilder = rootDefBuilder


### PR DESCRIPTION
Added warnings to prevent anyone else from using the (somehow broken) test suite created surveys.