### PR TITLE
AWS: Cognito IAM roles, refactor builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /app; set -o pipefail; ( \
 
 ############################################################
 
-FROM node:12-alpine AS prod
+FROM node:12-alpine AS arena-server
 RUN npm install pm2 -g
 
 COPY --from=prod_builder /app/node_modules /app/node_modules
@@ -44,7 +44,7 @@ CMD ["pm2-runtime", "server.js"]
 
 #############################################################
 
-FROM nginx:alpine AS prod_web
+FROM nginx:alpine AS arena-web
 COPY --from=prod_builder /app/server/run_nginx.sh /run_nginx.sh
 COPY --from=prod_builder /app/server/nginx_backend.conf.envsubst /etc/nginx/conf.d/backend.conf.envsubst
 COPY --from=prod_builder /app/server/nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: prod
+      target: arena-server
 
     environment:
       PGHOST: db
@@ -46,6 +46,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: prod_web
+      target: arena-web
     environment:
       ARENA_HOST: app_server:9090

--- a/infra/travis_push.sh
+++ b/infra/travis_push.sh
@@ -20,6 +20,7 @@ pulumi_up() {
 REPOSITORY_BASE=407725983764.dkr.ecr.eu-west-1.amazonaws.com
 
 push() {
+    # shellcheck disable=SC2091
     $(aws ecr get-login --no-include-email --region eu-west-1)
 
     pushd ..

--- a/infra/travis_push.sh
+++ b/infra/travis_push.sh
@@ -8,7 +8,8 @@ cd "$(dirname "$0")" || exit 1
 yarn install --frozen-lockfile
 
 # Require an annotated tag for automatic deploy to the QA/testing environment:
-commit_tag=$(git describe --exact-match HEAD 2>/dev/null || true)
+COMMIT_TAG=$(git describe --exact-match HEAD 2>/dev/null || true)
+COMMIT_HASH=$(git rev-parse HEAD)
 
 # Workaround for long ECS deploy durations causing timeouts
 # Revisit when there's progress with https://github.com/pulumi/pulumi/issues/3529
@@ -16,20 +17,41 @@ pulumi_up() {
     pulumi up --yes || pulumi up --yes
 }
 
+REPOSITORY_BASE=407725983764.dkr.ecr.eu-west-1.amazonaws.com
+
+push() {
+    $(aws ecr get-login --no-include-email --region eu-west-1)
+
+    pushd ..
+    for target in arena-server arena-web; do
+        docker build --target="$target" --tag "$target" .
+        docker tag "$target" "$REPOSITORY_BASE/$target:$COMMIT_HASH"
+        docker push "$REPOSITORY_BASE/$target:$COMMIT_HASH"
+        for stack in "$@"; do
+            docker tag "$target" "$REPOSITORY_BASE/$target:$stack"
+            docker push "$REPOSITORY_BASE/$target:$stack"
+        done
+    done
+    popd
+
+    for stack in "$@"; do
+        pulumi stack select "$stack"
+        pulumi_up
+    done
+}
+
 # Update the stack
 case ${TRAVIS_BRANCH} in
     master)
-        pulumi stack select arena-dev
-        pulumi_up
-        if [[ -n $commit_tag ]]; then
-            echo "Deploying tagged release to QA environment: $commit_tag"
-            pulumi stack select arena-test
-            pulumi_up
+        if [[ -n $COMMIT_TAG ]]; then
+            echo "Deploying tagged release to QA environment: $COMMIT_TAG"
+            push arena-dev arena-test
+        else
+            push arena-dev
         fi
         ;;
     production)
-        pulumi stack select arena-production
-        pulumi_up
+        push arena-prod
         ;;
     *)
         echo "No Pulumi stack associated with branch ${TRAVIS_BRANCH}."

--- a/server/db/migration/create-migration.sh
+++ b/server/db/migration/create-migration.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#! /usr/bin/env bash
+set -e
 
-if [ -z "$1" ]
+if [[ -z $1 ]]
   then
     echo "Give the name of the migration as parameter"
     exit 2
@@ -9,4 +10,8 @@ fi
 type=${2:-public}
 
 . .env
-db-migrate --config server/db/migration/migrationConfig.js --migrations-dir server/db/migration/$type/migrations create $1 --sql-file
+
+db-migrate \
+  --config server/db/migration/migrationConfig.js \
+  --migrations-dir server/db/migration/"$type"/migrations \
+  create "$1" --sql-file

--- a/server/run_nginx.sh
+++ b/server/run_nginx.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-set -euo pipefail
+set -eu
 envsubst < /etc/nginx/conf.d/backend.conf.envsubst > /etc/nginx/conf.d/backend.conf
 envsubst < index.html.envsubst > index.html
 exec nginx -g "daemon off;"

--- a/test/run_docker_tests.sh
+++ b/test/run_docker_tests.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-set -Eeu
+set -eu
 
 cleanup() {
     docker-compose -f test/docker-compose.test.yml rm -f


### PR DESCRIPTION
- Add Cognito IAM roles so Cognito is usable from ECS.

- Build/push containers in Travis CI, and only deploy them with Pulumi
(don't build them at deploy time).