### PR TITLE
NodeDef name changes

### DIFF
--- a/core/stringUtils.js
+++ b/core/stringUtils.js
@@ -18,7 +18,12 @@ export const isBlank = R.ifElse(isString, R.pipe(trim, R.isEmpty), R.isNil)
 
 export const isNotBlank = R.pipe(isBlank, R.not)
 
-export const normalizeName = R.pipe(leftTrim, R.toLower, R.replace(/[^a-z0-9]/g, '_'), R.slice(0, 60))
+/**
+ * NormalizeName: Make an identifier suitable for use in various contexts.
+ *
+ * Postgres in particular has a limit of 63 bytes per identifier, so reserve 23 bytes for prefixes and suffixes.
+ */
+export const normalizeName = R.pipe(leftTrim, R.toLower, R.replace(/[^a-z0-9]/g, '_'), R.slice(0, 40))
 
 export const capitalizeFirstLetter = text => text.charAt(0).toUpperCase() + text.slice(1)
 

--- a/core/validation/_validator/validatorFunctions.js
+++ b/core/validation/_validator/validatorFunctions.js
@@ -7,7 +7,7 @@ import * as ValidatorNameKeywords from './validatorNameKeywords'
 /**
  * Internal names must contain only lowercase letters, numbers and underscores starting with a letter
  */
-const validNameRegex = /^[a-z][a-z0-9_]*$/
+const validNameRegex = /^[a-z][a-z0-9_]{0,39}$/ // At most 40 characters long
 
 const getProp = (propName, defaultValue = null) => R.pathOr(defaultValue, propName.split('.'))
 

--- a/server/modules/nodeDef/manager/nodeDefManager.js
+++ b/server/modules/nodeDef/manager/nodeDefManager.js
@@ -11,6 +11,13 @@ import * as ActivityLogRepository from '@server/modules/activityLog/repository/a
 import * as NodeDefRepository from '../repository/nodeDefRepository'
 import { markSurveyDraft } from '../../survey/repository/surveySchemaRepositoryUtils'
 
+export {
+  addNodeDefsCycles,
+  deleteNodeDefsCycles,
+  permanentlyDeleteNodeDefs,
+  markNodeDefsWithoutCyclesDeleted,
+} from '../repository/nodeDefRepository'
+
 // ======= CREATE
 
 export const insertNodeDef = async (user, surveyId, nodeDefParam, system = false, client = db) =>
@@ -43,8 +50,6 @@ export const fetchNodeDefsBySurveyId = async (
   )
   return ObjectUtils.toUuidIndexedObj(nodeDefsDb)
 }
-
-export const fetchNodeDefByUuid = NodeDefRepository.fetchNodeDefByUuid
 
 // ======= UPDATE
 
@@ -130,10 +135,6 @@ export const updateNodeDefProps = async (
     }
   })
 
-export const addNodeDefsCycles = NodeDefRepository.addNodeDefsCycles
-
-export const deleteNodeDefsCycles = NodeDefRepository.deleteNodeDefsCycles
-
 export const publishNodeDefsProps = async (surveyId, langsDeleted, client = db) => {
   await NodeDefRepository.publishNodeDefsProps(surveyId, client)
 
@@ -160,6 +161,3 @@ export const markNodeDefDeleted = async (user, surveyId, nodeDefUuid) =>
 
     return nodeDef
   })
-
-export const permanentlyDeleteNodeDefs = NodeDefRepository.permanentlyDeleteNodeDefs
-export const markNodeDefsWithoutCyclesDeleted = NodeDefRepository.markNodeDefsWithoutCyclesDeleted

--- a/server/modules/nodeDef/repository/nodeDefRepository.js
+++ b/server/modules/nodeDef/repository/nodeDefRepository.js
@@ -94,15 +94,6 @@ export const fetchNodeDefByUuid = async (surveyId, nodeDefUuid, draft, advanced 
     res => dbTransformCallback(res, draft, advanced),
   )
 
-export const fetchNodeDefsByUuid = async (surveyId, nodeDefUuids = [], draft = false, advanced = false, client = db) =>
-  await client.map(
-    `SELECT ${nodeDefSelectFields}
-     FROM ${getSurveyDBSchema(surveyId)}.node_def 
-     WHERE uuid in (${nodeDefUuids.map((uuid, i) => `$${i + 1}`).join(',')})`,
-    [...nodeDefUuids],
-    res => dbTransformCallback(res, draft, advanced),
-  )
-
 const fetchNodeDefsByParentUuid = async (surveyId, parentUuid, draft, client = db) =>
   await client.map(
     `
@@ -142,19 +133,6 @@ export const updateNodeDefProps = async (surveyId, nodeDefUuid, props, propsAdva
   `,
     [props, propsAdvanced, nodeDefUuid],
     def => dbTransformCallback(def, true, true), // Always loading draft when creating or updating a nodeDef
-  )
-
-export const updateNodeDefPropsPublished = async (surveyId, nodeDefUuid, props, propsAdvanced = {}, client = db) =>
-  await client.one(
-    `
-    UPDATE ${getSurveyDBSchema(surveyId)}.node_def 
-    SET props = props || $1::jsonb,
-        props_advanced = props_advanced || $2::jsonb
-    WHERE uuid = $3
-    RETURNING ${nodeDefSelectFields}
-  `,
-    [props, propsAdvanced, nodeDefUuid],
-    def => dbTransformCallback(def, false, true),
   )
 
 // CYCLES


### PR DESCRIPTION
This makes sure all identifiers are at most 40 characters so that any prefixes and suffixes in use with Postgres fit in the 63 character (byte) limit of Postgres' identifiers.
