### PR TITLE
NodeDefDetails: show categories manager in PanelRight when editing node def

### DIFF
--- a/core/i18n/resources/en.js
+++ b/core/i18n/resources/en.js
@@ -515,6 +515,7 @@ $t(common.cantUndoWarning)`,
   },
 
   categoryEdit: {
+    header: 'Category',
     addLevel: 'Add level',
     categoryName: 'Category name',
     cantBeDeleted: `$t(common.cantBeDeletedUsedItem, {'item': 'category'})`,

--- a/webapp/app/appModules.js
+++ b/webapp/app/appModules.js
@@ -146,10 +146,6 @@ export const analysisModules = {
     key: 'nodeDef',
     path: `${appModules.analysis.path}/nodeDef`,
   },
-  categories: {
-    key: 'categories',
-    path: `${appModules.analysis.path}/categories`,
-  },
   category: {
     key: 'category',
     path: `${appModules.analysis.path}/category`,

--- a/webapp/components/PanelRight/PanelRight.js
+++ b/webapp/components/PanelRight/PanelRight.js
@@ -6,7 +6,7 @@ const PanelRight = (props) => {
   const { children, header, onClose, width } = props
 
   return (
-    <div className="panel-right" style={{ width: `min(${width}px, 100vw)` }}>
+    <div className="panel-right" style={{ width: `min(${width}, 100vw)` }}>
       <div className="panel-right__header">
         <button type="button" className="btn btn-transparent btn-close" onClick={onClose}>
           <span className="icon icon-cross icon-12px" />
@@ -22,7 +22,7 @@ PanelRight.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
   header: PropTypes.node,
   onClose: PropTypes.func.isRequired,
-  width: PropTypes.number, // width of the panel in px
+  width: PropTypes.string, // width of the panel (e.g. '1000px' or '90vw')
 }
 
 PanelRight.defaultProps = {

--- a/webapp/components/PanelRight/PanelRight.js
+++ b/webapp/components/PanelRight/PanelRight.js
@@ -27,7 +27,7 @@ PanelRight.propTypes = {
 
 PanelRight.defaultProps = {
   header: '',
-  width: 500,
+  width: '500px',
 }
 
 export default PanelRight

--- a/webapp/components/expression/expressionEditorPopup.js
+++ b/webapp/components/expression/expressionEditorPopup.js
@@ -55,7 +55,7 @@ const ExpressionEditorPopup = (props) => {
   const i18n = useI18n()
 
   return (
-    <PanelRight onClose={onClose} width={1020}>
+    <PanelRight onClose={onClose} width="1020px">
       <div className="expression-editor-popup">
         <button
           type="button"

--- a/webapp/components/survey/CategorySelector/CategorySelector.js
+++ b/webapp/components/survey/CategorySelector/CategorySelector.js
@@ -16,6 +16,7 @@ import CategoriesView from '@webapp/loggedin/surveyViews/categories/categoriesVi
 import { useSurvey } from '@webapp/store/survey'
 
 import * as CategoryActions from '@webapp/loggedin/surveyViews/category/actions'
+import CategoryView from '@webapp/loggedin/surveyViews/category/categoryView'
 
 const CategorySelector = (props) => {
   const { disabled, categoryUuid, validation, showManage, showAdd, onChange } = props
@@ -25,10 +26,17 @@ const CategorySelector = (props) => {
   const dispatch = useDispatch()
 
   const [showCategoriesPanel, setShowCategoriesPanel] = useState(false)
+  const [showCategoryPanel, setShowCategoryPanel] = useState(false)
 
   const survey = useSurvey()
   const categories = Survey.getCategoriesArray(survey)
   const category = Survey.getCategoryByUuid(categoryUuid)(survey)
+
+  const onAdd = async () => {
+    const newCategory = await dispatch(CategoryActions.createCategory())
+    onChange(newCategory)
+    setShowCategoryPanel(true)
+  }
 
   return (
     <div className="category-selector">
@@ -46,16 +54,24 @@ const CategorySelector = (props) => {
           type="button"
           className="btn btn-s"
           style={{ justifySelf: 'center' }}
-          onClick={async () => {
-            const newCategory = await dispatch(CategoryActions.createCategory())
-            onChange(newCategory)
-            setShowCategoriesPanel(true)
-          }}
+          onClick={onAdd}
           aria-disabled={disabled}
         >
           <span className="icon icon-plus icon-12px icon-left" />
           {i18n.t('common.add')}
         </button>
+      )}
+      {showCategoryPanel && (
+        <PanelRight
+          width="90vw"
+          onClose={async () => {
+            await dispatch(CategoryActions.setCategoryForEdit(null))
+            setShowCategoryPanel(false)
+          }}
+          header={i18n.t('categoryEdit.header')}
+        >
+          <CategoryView showClose={false} />
+        </PanelRight>
       )}
       {showManage && (
         <button

--- a/webapp/components/survey/CategorySelector/CategorySelector.js
+++ b/webapp/components/survey/CategorySelector/CategorySelector.js
@@ -1,30 +1,31 @@
 import './CategorySelector.scss'
 
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-
 import { useDispatch } from 'react-redux'
-import { Link, useHistory } from 'react-router-dom'
 
 import * as Survey from '@core/survey/survey'
 import * as Category from '@core/survey/category'
 
 import { useI18n } from '@webapp/store/system'
 import Dropdown from '@webapp/components/form/dropdown'
+import PanelRight from '@webapp/components/PanelRight'
 
-import { appModuleUri, designerModules, analysisModules } from '@webapp/app/appModules'
+import CategoriesView from '@webapp/loggedin/surveyViews/categories/categoriesView'
 
 import { useSurvey } from '@webapp/store/survey'
 
-import { createCategory } from '@webapp/loggedin/surveyViews/category/actions'
+import * as CategoryActions from '@webapp/loggedin/surveyViews/category/actions'
 
 const CategorySelector = (props) => {
-  const { disabled, categoryUuid, validation, showManage, showAdd, analysis, onChange } = props
+  const { disabled, categoryUuid, validation, showManage, showAdd, onChange } = props
 
   const i18n = useI18n()
 
   const dispatch = useDispatch()
-  const history = useHistory()
+
+  const [showCategoriesPanel, setShowCategoriesPanel] = useState(false)
+
   const survey = useSurvey()
   const categories = Survey.getCategoriesArray(survey)
   const category = Survey.getCategoryByUuid(categoryUuid)(survey)
@@ -46,8 +47,9 @@ const CategorySelector = (props) => {
           className="btn btn-s"
           style={{ justifySelf: 'center' }}
           onClick={async () => {
-            const newCategory = await dispatch(createCategory(history, analysis))
+            const newCategory = await dispatch(CategoryActions.createCategory())
             onChange(newCategory)
+            setShowCategoriesPanel(true)
           }}
           aria-disabled={disabled}
         >
@@ -56,14 +58,20 @@ const CategorySelector = (props) => {
         </button>
       )}
       {showManage && (
-        <Link
+        <button
+          type="button"
           className="btn btn-s"
           style={{ justifySelf: 'center' }}
-          to={appModuleUri(analysis ? analysisModules.categories : designerModules.categories)}
+          onClick={() => setShowCategoriesPanel(true)}
         >
           <span className="icon icon-list icon-12px icon-left" />
           {i18n.t('common.manage')}
-        </Link>
+        </button>
+      )}
+      {showCategoriesPanel && (
+        <PanelRight width="90vw" onClose={() => setShowCategoriesPanel(false)} header={i18n.t('appModules.categories')}>
+          <CategoriesView canSelect selectedItemUuid={categoryUuid} onSelect={onChange} />
+        </PanelRight>
       )}
     </div>
   )
@@ -75,7 +83,6 @@ CategorySelector.propTypes = {
   disabled: PropTypes.bool,
   showManage: PropTypes.bool,
   showAdd: PropTypes.bool,
-  analysis: PropTypes.bool,
   onChange: PropTypes.func,
 }
 
@@ -85,7 +92,6 @@ CategorySelector.defaultProps = {
   disabled: false,
   showManage: true,
   showAdd: true,
-  analysis: false, // True if used inside analysis/nodeDef editor
   onChange: () => ({}),
 }
 

--- a/webapp/components/survey/CategorySelector/CategorySelector.js
+++ b/webapp/components/survey/CategorySelector/CategorySelector.js
@@ -61,18 +61,6 @@ const CategorySelector = (props) => {
           {i18n.t('common.add')}
         </button>
       )}
-      {showCategoryPanel && (
-        <PanelRight
-          width="90vw"
-          onClose={async () => {
-            await dispatch(CategoryActions.setCategoryForEdit(null))
-            setShowCategoryPanel(false)
-          }}
-          header={i18n.t('categoryEdit.header')}
-        >
-          <CategoryView showClose={false} />
-        </PanelRight>
-      )}
       {showManage && (
         <button
           type="button"
@@ -84,8 +72,24 @@ const CategorySelector = (props) => {
           {i18n.t('common.manage')}
         </button>
       )}
+      {showCategoryPanel && (
+        <PanelRight
+          width="100vw"
+          onClose={async () => {
+            await dispatch(CategoryActions.setCategoryForEdit(null))
+            setShowCategoryPanel(false)
+          }}
+          header={i18n.t('categoryEdit.header')}
+        >
+          <CategoryView showClose={false} />
+        </PanelRight>
+      )}
       {showCategoriesPanel && (
-        <PanelRight width="90vw" onClose={() => setShowCategoriesPanel(false)} header={i18n.t('appModules.categories')}>
+        <PanelRight
+          width="100vw"
+          onClose={() => setShowCategoriesPanel(false)}
+          header={i18n.t('appModules.categories')}
+        >
           <CategoriesView canSelect selectedItemUuid={categoryUuid} onSelect={onChange} />
         </PanelRight>
       )}

--- a/webapp/components/survey/NodeDefDetails/CodeProps.js
+++ b/webapp/components/survey/NodeDefDetails/CodeProps.js
@@ -55,6 +55,7 @@ const CodeProps = (props) => {
           disabled={disabled}
           categoryUuid={NodeDef.getCategoryUuid(nodeDef)}
           validation={Validation.getFieldValidation(NodeDef.propKeys.categoryUuid)(validation)}
+          editingNodeDef
           analysis={NodeDef.isAnalysis(nodeDef)}
           onChange={setCategoryProp}
         />

--- a/webapp/loggedin/surveyViews/categories/categoriesView.js
+++ b/webapp/loggedin/surveyViews/categories/categoriesView.js
@@ -82,11 +82,11 @@ const CategoriesView = (props) => {
       />
       {editedCategory && (
         <PanelRight
-          width="80vw"
+          width="100vw"
           header={i18n.t('categoryEdit.header')}
           onClose={() => dispatch(CategoryActions.setCategoryForEdit(null))}
         >
-          <CategoryView />
+          <CategoryView showClose={false} />
         </PanelRight>
       )}
     </>

--- a/webapp/loggedin/surveyViews/categories/categoriesView.js
+++ b/webapp/loggedin/surveyViews/categories/categoriesView.js
@@ -1,68 +1,34 @@
 import React from 'react'
-import { connect, useDispatch } from 'react-redux'
+import PropTypes from 'prop-types'
+import { useSelector, useDispatch } from 'react-redux'
 import * as R from 'ramda'
 
 import { useI18n } from '@webapp/store/system'
-import { useHistory } from 'react-router'
 
 import * as Survey from '@core/survey/survey'
-import * as NodeDef from '@core/survey/nodeDef'
 import * as Category from '@core/survey/category'
-import * as Authorizer from '@core/auth/authorizer'
-import { appModuleUri, designerModules, analysisModules } from '@webapp/app/appModules'
+
+import PanelRight from '@webapp/components/PanelRight'
 
 import { DialogConfirmActions, NotificationActions } from '@webapp/store/ui'
 import { SurveyState } from '@webapp/store/survey'
-import { UserState } from '@webapp/store/user'
-import * as NodeDefState from '@webapp/loggedin/surveyViews/nodeDef/nodeDefState'
+import { useAuthCanEditSurvey } from '@webapp/store/user'
 
-import { createCategory, deleteCategory } from '../category/actions'
 import ItemsView from '../items/itemsView'
+import CategoryView from '../category/categoryView'
+
+import * as CategoryActions from '../category/actions'
+import * as CategoryState from '../category/categoryState'
 
 const CategoriesView = (props) => {
-  const { categories, nodeDef, createCategory, deleteCategory, canSelect, readOnly, analysis, setNodeDefProp } = props
-  const selectedItemUuid = nodeDef && NodeDef.getCategoryUuid(nodeDef)
+  const { canSelect, onSelect, selectedItemUuid, onClose } = props
 
   const i18n = useI18n()
-  const history = useHistory()
   const dispatch = useDispatch()
 
-  const onClose = nodeDef ? history.goBack : null
-
-  const canDeleteCategory = (category) =>
-    category.usedByNodeDefs ? dispatch(NotificationActions.notifyInfo({ key: 'categoryEdit.cantBeDeleted' })) : true
-
-  const onDelete = (category) =>
-    dispatch(
-      DialogConfirmActions.showDialogConfirm({
-        key: 'categoryEdit.confirmDelete',
-        params: { categoryName: Category.getName(category) || i18n.t('common.undefinedName') },
-        onOk: () => deleteCategory(category),
-      })
-    )
-
-  return (
-    <ItemsView
-      itemLabelFunction={(category) => Category.getName(category)}
-      itemLink={appModuleUri(analysis ? analysisModules.category : designerModules.category)}
-      items={categories}
-      selectedItemUuid={selectedItemUuid}
-      onAdd={createCategory}
-      canDelete={canDeleteCategory}
-      onDelete={onDelete}
-      canSelect={canSelect}
-      onSelect={(category) => setNodeDefProp(NodeDef.propKeys.categoryUuid, Category.getUuid(category))}
-      onClose={onClose}
-      readOnly={readOnly}
-    />
-  )
-}
-
-const mapStateToProps = (state) => {
-  const survey = SurveyState.getSurvey(state)
-  const surveyInfo = SurveyState.getSurveyInfo(state)
-  const user = UserState.getUser(state)
-  const readOnly = !Authorizer.canEditSurvey(user, surveyInfo)
+  const survey = useSelector(SurveyState.getSurvey)
+  const readOnly = !useAuthCanEditSurvey()
+  const editedCategory = useSelector(CategoryState.getCategoryForEdit)
   const categories = R.pipe(
     Survey.getCategoriesArray,
     R.map((category) => ({
@@ -70,21 +36,66 @@ const mapStateToProps = (state) => {
       usedByNodeDefs: !R.isEmpty(Survey.getNodeDefsByCategoryUuid(Category.getUuid(category))(survey)),
     }))
   )(survey)
-  // A nodeDef code is begin edited.
-  const nodeDef = !readOnly && NodeDefState.getNodeDef(state)
-  const canSelect = nodeDef && NodeDef.isCode(nodeDef) && Survey.canUpdateCategory(nodeDef)(survey)
 
-  return {
-    categories,
-    readOnly,
-    nodeDef,
-    canSelect,
+  const canDeleteCategory = (category) =>
+    category.usedByNodeDefs ? dispatch(NotificationActions.notifyInfo({ key: 'categoryEdit.cantBeDeleted' })) : true
+
+  const onAdd = async () => {
+    const category = await dispatch(CategoryActions.createCategory())
+    if (onSelect) {
+      onSelect(category)
+    }
   }
+
+  const onDelete = (category) =>
+    dispatch(
+      DialogConfirmActions.showDialogConfirm({
+        key: 'categoryEdit.confirmDelete',
+        params: { categoryName: Category.getName(category) || i18n.t('common.undefinedName') },
+        onOk: () => dispatch(CategoryActions.deleteCategory(category)),
+      })
+    )
+
+  return (
+    <>
+      <ItemsView
+        itemLabelFunction={Category.getName}
+        items={categories}
+        selectedItemUuid={selectedItemUuid}
+        onAdd={onAdd}
+        onEdit={(category) => dispatch(CategoryActions.setCategoryForEdit(Category.getUuid(category)))}
+        canDelete={canDeleteCategory}
+        onDelete={onDelete}
+        canSelect={canSelect}
+        onSelect={onSelect}
+        onClose={onClose}
+        readOnly={readOnly}
+      />
+      {editedCategory && (
+        <PanelRight
+          width="80vw"
+          header={i18n.t('categoryEdit.header')}
+          onClose={() => dispatch(CategoryActions.setCategoryForEdit(null))}
+        >
+          <CategoryView />
+        </PanelRight>
+      )}
+    </>
+  )
 }
 
-export default connect(mapStateToProps, {
-  createCategory,
-  deleteCategory,
-  //TODO update node def category on category selection when refactoring
-  setNodeDefProp: () => {},
-})(CategoriesView)
+CategoriesView.propTypes = {
+  canSelect: PropTypes.bool,
+  onSelect: PropTypes.func,
+  selectedItemUuid: PropTypes.string,
+  onClose: PropTypes.func,
+}
+
+CategoriesView.defaultProps = {
+  canSelect: false,
+  onSelect: null,
+  selectedItemUuid: null,
+  onClose: null,
+}
+
+export default CategoriesView

--- a/webapp/loggedin/surveyViews/categories/categoriesView.js
+++ b/webapp/loggedin/surveyViews/categories/categoriesView.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { useSelector, useDispatch } from 'react-redux'
+import { matchPath, useLocation } from 'react-router'
 import * as R from 'ramda'
 
 import { useI18n } from '@webapp/store/system'
@@ -9,6 +10,8 @@ import * as Survey from '@core/survey/survey'
 import * as Category from '@core/survey/category'
 
 import PanelRight from '@webapp/components/PanelRight'
+
+import { designerModules, appModuleUri } from '@webapp/app/appModules'
 
 import { DialogConfirmActions, NotificationActions } from '@webapp/store/ui'
 import { SurveyState } from '@webapp/store/survey'
@@ -25,6 +28,9 @@ const CategoriesView = (props) => {
 
   const i18n = useI18n()
   const dispatch = useDispatch()
+  const { pathname } = useLocation()
+
+  const inCategoriesPath = Boolean(matchPath(pathname, appModuleUri(designerModules.categories)))
 
   const survey = useSelector(SurveyState.getSurvey)
   const readOnly = !useAuthCanEditSurvey()
@@ -61,9 +67,12 @@ const CategoriesView = (props) => {
       <ItemsView
         itemLabelFunction={Category.getName}
         items={categories}
+        itemLink={inCategoriesPath ? appModuleUri(designerModules.category) : null}
         selectedItemUuid={selectedItemUuid}
         onAdd={onAdd}
-        onEdit={(category) => dispatch(CategoryActions.setCategoryForEdit(Category.getUuid(category)))}
+        onEdit={(category) =>
+          !inCategoriesPath && dispatch(CategoryActions.setCategoryForEdit(Category.getUuid(category)))
+        }
         canDelete={canDeleteCategory}
         onDelete={onDelete}
         canSelect={canSelect}

--- a/webapp/loggedin/surveyViews/category/categoryView.js
+++ b/webapp/loggedin/surveyViews/category/categoryView.js
@@ -114,7 +114,7 @@ CategoryView.propTypes = {
 }
 
 CategoryView.defaultProps = {
-  showClose: false,
+  showClose: true,
 }
 
 export default CategoryView

--- a/webapp/loggedin/surveyViews/category/categoryView.js
+++ b/webapp/loggedin/surveyViews/category/categoryView.js
@@ -1,8 +1,9 @@
 import './categoryView.scss'
 
 import React, { useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { useDispatch, useSelector } from 'react-redux'
-import { useParams } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 
 import * as StringUtils from '@core/stringUtils'
 import * as Category from '@core/survey/category'
@@ -20,10 +21,12 @@ import LevelEdit from './components/levelEdit'
 
 import * as Actions from './actions'
 
-const CategoryView = () => {
+const CategoryView = (props) => {
+  const { showClose } = props
   const { categoryUuid } = useParams()
   const i18n = useI18n()
   const dispatch = useDispatch()
+  const history = useHistory()
 
   const category = useSelector(CategoryState.getCategoryForEdit)
   const importSummary = useSelector(CategoryState.getImportSummary)
@@ -31,6 +34,8 @@ const CategoryView = () => {
 
   const validation = Validation.getValidation(category)
   const levels = Category.getLevelsArray(category)
+
+  const inCategoriesPath = Boolean(categoryUuid)
 
   useEffect(() => {
     if (categoryUuid) {
@@ -82,15 +87,34 @@ const CategoryView = () => {
         </div>
 
         <div className="button-bar">
-          <button type="button" className="btn" onClick={() => dispatch(Actions.setCategoryForEdit(null))}>
-            {i18n.t('common.done')}
-          </button>
+          {showClose && (
+            <button
+              type="button"
+              className="btn"
+              onClick={async () => {
+                await dispatch(Actions.setCategoryForEdit(null))
+                if (inCategoriesPath) {
+                  history.goBack()
+                }
+              }}
+            >
+              {i18n.t('common.done')}
+            </button>
+          )}
         </div>
       </div>
 
       {importSummary && <CategoryImportSummary summary={importSummary} />}
     </>
   ) : null
+}
+
+CategoryView.propTypes = {
+  showClose: PropTypes.bool,
+}
+
+CategoryView.defaultProps = {
+  showClose: false,
 }
 
 export default CategoryView

--- a/webapp/loggedin/surveyViews/category/categoryView.js
+++ b/webapp/loggedin/surveyViews/category/categoryView.js
@@ -1,48 +1,41 @@
 import './categoryView.scss'
 
 import React, { useEffect } from 'react'
-import { connect } from 'react-redux'
-import { useHistory, useParams } from 'react-router'
+import { useDispatch, useSelector } from 'react-redux'
+import { useParams } from 'react-router'
 
 import * as StringUtils from '@core/stringUtils'
-import * as Authorizer from '@core/auth/authorizer'
 import * as Category from '@core/survey/category'
 import * as CategoryLevel from '@core/survey/categoryLevel'
 import * as Validation from '@core/validation/validation'
 
 import { useI18n } from '@webapp/store/system'
-import { UserState } from '@webapp/store/user'
+import { useAuthCanEditSurvey } from '@webapp/store/user'
 import { FormItem, Input } from '@webapp/components/form/input'
 import UploadButton from '@webapp/components/form/uploadButton'
 
-import { SurveyState } from '@webapp/store/survey'
 import * as CategoryState from './categoryState'
 import CategoryImportSummary from './components/categoryImportSummary'
 import LevelEdit from './components/levelEdit'
 
-import { putCategoryProp, createCategoryLevel, setCategoryForEdit, uploadCategory } from './actions'
+import * as Actions from './actions'
 
-
-const CategoryView = props => {
-  const {
-    category,
-    readOnly,
-    importSummary,
-    putCategoryProp,
-    createCategoryLevel,
-    setCategoryForEdit,
-    uploadCategory,
-  } = props
-
-  const history = useHistory()
+const CategoryView = () => {
   const { categoryUuid } = useParams()
   const i18n = useI18n()
+  const dispatch = useDispatch()
+
+  const category = useSelector(CategoryState.getCategoryForEdit)
+  const importSummary = useSelector(CategoryState.getImportSummary)
+  const readOnly = !useAuthCanEditSurvey()
 
   const validation = Validation.getValidation(category)
   const levels = Category.getLevelsArray(category)
 
   useEffect(() => {
-    setCategoryForEdit(categoryUuid)
+    if (categoryUuid) {
+      dispatch(Actions.setCategoryForEdit(categoryUuid))
+    }
   }, [])
 
   return category ? (
@@ -53,7 +46,9 @@ const CategoryView = props => {
             <Input
               value={Category.getName(category)}
               validation={Validation.getFieldValidation(Category.props.name)(validation)}
-              onChange={value => putCategoryProp(category, Category.props.name, StringUtils.normalizeName(value))}
+              onChange={(value) =>
+                dispatch(Actions.putCategoryProp(category, Category.props.name, StringUtils.normalizeName(value)))
+              }
               readOnly={readOnly}
             />
           </FormItem>
@@ -62,21 +57,22 @@ const CategoryView = props => {
             <UploadButton
               label={i18n.t('common.csvImport')}
               accept=".csv"
-              onChange={files => uploadCategory(Category.getUuid(category), files[0])}
+              onChange={(files) => dispatch(Actions.uploadCategory(Category.getUuid(category), files[0]))}
               disabled={Category.isPublished(category)}
             />
           )}
         </div>
 
         <div className="category__levels">
-          {levels.map(level => (
+          {levels.map((level) => (
             <LevelEdit key={CategoryLevel.getUuid(level)} level={level} />
           ))}
 
           {!readOnly && (
             <button
+              type="button"
               className="btn btn-s btn-add-level"
-              onClick={() => createCategoryLevel(category)}
+              onClick={() => dispatch(Actions.createCategoryLevel(category))}
               aria-disabled={levels.length === 5}
             >
               <span className="icon icon-plus icon-16px icon-left" />
@@ -86,13 +82,7 @@ const CategoryView = props => {
         </div>
 
         <div className="button-bar">
-          <button
-            className="btn"
-            onClick={() => {
-              history.goBack()
-              setCategoryForEdit(null)
-            }}
-          >
+          <button type="button" className="btn" onClick={() => dispatch(Actions.setCategoryForEdit(null))}>
             {i18n.t('common.done')}
           </button>
         </div>
@@ -103,15 +93,4 @@ const CategoryView = props => {
   ) : null
 }
 
-const mapStateToProps = state => ({
-  category: CategoryState.getCategoryForEdit(state),
-  readOnly: !Authorizer.canEditSurvey(UserState.getUser(state), SurveyState.getSurveyInfo(state)),
-  importSummary: CategoryState.getImportSummary(state),
-})
-
-export default connect(mapStateToProps, {
-  putCategoryProp,
-  createCategoryLevel,
-  setCategoryForEdit,
-  uploadCategory,
-})(CategoryView)
+export default CategoryView

--- a/webapp/loggedin/surveyViews/items/itemsTable.js
+++ b/webapp/loggedin/surveyViews/items/itemsTable.js
@@ -1,80 +1,32 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import * as R from 'ramda'
-import { Link, useHistory } from 'react-router-dom'
-
-import * as ObjectUtils from '@core/objectUtils'
 
 import { useI18n } from '@webapp/store/system'
 
-const TableRow = props => {
-  const { columns, item, itemLink, selectedItemUuid, canSelect, onSelect, canDelete, onDelete, readOnly } = props
+import ItemsTableRow from './itemsTableRow'
+import ItemsTableHeader from './itemsTableHeader'
 
-  const i18n = useI18n()
-
-  const selected = item.uuid === selectedItemUuid
-
-  return (
-    <div className="table__row">
-      {columns.map((column, idx) => (
-        <div key={idx} className={column.className}>
-          {React.createElement(column.cellRenderer, props)}
-        </div>
-      ))}
-
-      <div className="buttons">
-        {onSelect && (canSelect || selected) && (
-          <button className={`btn btn-s${selected ? ' active' : ''}`} onClick={() => onSelect(item)}>
-            <span className={`icon icon-checkbox-${selected ? '' : 'un'}checked icon-12px icon-left`} />
-            {selected ? i18n.t(`common.selected`) : i18n.t(`common.select`)}
-          </button>
-        )}
-
-        <Link className="btn btn-s" to={`${itemLink}${ObjectUtils.getUuid(item)}/`}>
-          <span className={`icon icon-${readOnly ? 'eye' : 'pencil2'} icon-12px icon-left`} />
-          {readOnly ? i18n.t('common.view') : i18n.t('common.edit')}
-        </Link>
-
-        {!readOnly && (
-          <button
-            className="btn btn-s"
-            onClick={() => {
-              if (canDelete(item)) {
-                onDelete(item)
-              }
-            }}
-          >
-            <span className="icon icon-bin2 icon-12px icon-left" />
-            {i18n.t('common.delete')}
-          </button>
-        )}
-      </div>
-    </div>
-  )
-}
-
-const Header = ({ onAdd, readOnly }) => {
-  const i18n = useI18n()
-  const history = useHistory()
-
-  return (
-    !readOnly && (
-      <div className="table__header">
-        <button className="btn btn-s" onClick={() => onAdd(history)}>
-          <span className="icon icon-plus icon-12px icon-left" />
-          {i18n.t('common.add')}
-        </button>
-      </div>
-    )
-  )
-}
-
-const ItemsTable = props => {
-  const { items, columns } = props
+const ItemsTable = (props) => {
+  const {
+    onAdd,
+    readOnly,
+    items,
+    columns,
+    itemLink,
+    itemLabelFunction,
+    selectedItemUuid,
+    canSelect,
+    onSelect,
+    canDelete,
+    onDelete,
+    onEdit,
+  } = props
   const i18n = useI18n()
 
   return (
     <div className="table">
-      <Header {...props} />
+      <ItemsTableHeader onAdd={onAdd} readOnly={readOnly} />
 
       {R.isEmpty(items) ? (
         <div className="table__empty-rows">{i18n.t('itemsTable.noItemsAdded')}</div>
@@ -82,7 +34,7 @@ const ItemsTable = props => {
         <div className="table__content">
           <div className="table__row-header">
             {columns.map((column, idx) => (
-              <div key={idx} className={column.className}>
+              <div key={String(idx)} className={column.className}>
                 {i18n.t(column.heading)}
               </div>
             ))}
@@ -90,14 +42,55 @@ const ItemsTable = props => {
           </div>
 
           <div className="table__rows">
-            {items.map(item => (
-              <TableRow {...props} key={item.uuid} item={item} />
+            {items.map((item) => (
+              <ItemsTableRow
+                key={item.uuid}
+                item={item}
+                columns={columns}
+                itemLink={itemLink}
+                itemLabelFunction={itemLabelFunction}
+                selectedItemUuid={selectedItemUuid}
+                canSelect={canSelect}
+                canDelete={canDelete}
+                readOnly={readOnly}
+                onSelect={onSelect}
+                onEdit={onEdit}
+                onDelete={onDelete}
+              />
             ))}
           </div>
         </div>
       )}
     </div>
   )
+}
+
+ItemsTable.propTypes = {
+  columns: PropTypes.arrayOf(Object).isRequired,
+  items: PropTypes.array.isRequired,
+  itemLink: PropTypes.string,
+  itemLabelFunction: PropTypes.func,
+  selectedItemUuid: PropTypes.string,
+  canSelect: PropTypes.bool,
+  canDelete: PropTypes.func,
+  readOnly: PropTypes.bool,
+  onAdd: PropTypes.func,
+  onSelect: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+}
+
+ItemsTable.defaultProps = {
+  itemLink: null,
+  itemLabelFunction: null,
+  selectedItemUuid: null,
+  canSelect: false,
+  canDelete: null,
+  readOnly: true,
+  onAdd: null,
+  onSelect: null,
+  onEdit: null,
+  onDelete: null,
 }
 
 export default ItemsTable

--- a/webapp/loggedin/surveyViews/items/itemsTableHeader.js
+++ b/webapp/loggedin/surveyViews/items/itemsTableHeader.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useHistory } from 'react-router'
+
+import { useI18n } from '@webapp/store/system'
+
+const ItemsTableHeader = ({ onAdd, readOnly }) => {
+  const i18n = useI18n()
+  const history = useHistory()
+
+  return (
+    !readOnly && (
+      <div className="table__header">
+        <button type="button" className="btn btn-s" onClick={() => onAdd(history)}>
+          <span className="icon icon-plus icon-12px icon-left" />
+          {i18n.t('common.add')}
+        </button>
+      </div>
+    )
+  )
+}
+
+ItemsTableHeader.propTypes = {
+  onAdd: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool.isRequired,
+}
+
+export default ItemsTableHeader

--- a/webapp/loggedin/surveyViews/items/itemsTableRow.js
+++ b/webapp/loggedin/surveyViews/items/itemsTableRow.js
@@ -1,0 +1,97 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { useHistory } from 'react-router'
+
+import * as ObjectUtils from '@core/objectUtils'
+
+import { useI18n } from '@webapp/store/system'
+
+const ItemsTableRow = (props) => {
+  const {
+    columns,
+    item,
+    itemLink,
+    selectedItemUuid,
+    canSelect,
+    onSelect,
+    onEdit,
+    canDelete,
+    onDelete,
+    readOnly,
+  } = props
+
+  const i18n = useI18n()
+  const history = useHistory()
+
+  const itemUuid = ObjectUtils.getUuid(item)
+  const selected = itemUuid === selectedItemUuid
+
+  return (
+    <div className="table__row">
+      {columns.map((column, idx) => (
+        <div key={String(idx)} className={column.className}>
+          {React.createElement(column.cellRenderer, props)}
+        </div>
+      ))}
+
+      <div className="buttons">
+        {onSelect && (canSelect || selected) && (
+          <button type="button" className={`btn btn-s${selected ? ' active' : ''}`} onClick={() => onSelect(item)}>
+            <span className={`icon icon-checkbox-${selected ? '' : 'un'}checked icon-12px icon-left`} />
+            {selected ? i18n.t(`common.selected`) : i18n.t(`common.select`)}
+          </button>
+        )}
+
+        <button
+          type="button"
+          className="btn btn-s"
+          onClick={() => (itemLink ? history.push(`${itemLink}${itemUuid}/`) : onEdit(item))}
+        >
+          <span className={`icon icon-${readOnly ? 'eye' : 'pencil2'} icon-12px icon-left`} />
+          {readOnly ? i18n.t('common.view') : i18n.t('common.edit')}
+        </button>
+
+        {!readOnly && (
+          <button
+            type="button"
+            className="btn btn-s"
+            onClick={() => {
+              if (canDelete && canDelete(item)) {
+                onDelete(item)
+              }
+            }}
+          >
+            <span className="icon icon-bin2 icon-12px icon-left" />
+            {i18n.t('common.delete')}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+ItemsTableRow.propTypes = {
+  columns: PropTypes.arrayOf(Object).isRequired,
+  item: PropTypes.object.isRequired,
+  itemLink: PropTypes.string,
+  selectedItemUuid: PropTypes.string,
+  canSelect: PropTypes.bool,
+  canDelete: PropTypes.func,
+  readOnly: PropTypes.bool,
+  onSelect: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+}
+
+ItemsTableRow.defaultProps = {
+  itemLink: null,
+  selectedItemUuid: null,
+  canSelect: false,
+  canDelete: null,
+  readOnly: true,
+  onSelect: null,
+  onEdit: null,
+  onDelete: null,
+}
+
+export default ItemsTableRow

--- a/webapp/loggedin/surveyViews/items/itemsView.js
+++ b/webapp/loggedin/surveyViews/items/itemsView.js
@@ -1,6 +1,7 @@
 import './itemsView.scss'
 
 import React from 'react'
+import PropTypes from 'prop-types'
 import * as R from 'ramda'
 
 import { useI18n } from '@webapp/store/system'
@@ -10,7 +11,7 @@ import WarningBadge from '@webapp/components/warningBadge'
 import ItemsTable from './itemsTable'
 import ItemsColumn from './itemsColumn'
 
-const CellRendererName = props => {
+const CellRendererName = (props) => {
   const { item, itemLabelFunction } = props
 
   const i18n = useI18n()
@@ -26,17 +27,51 @@ const CellRendererName = props => {
   )
 }
 
-const ItemsView = props => {
-  const { className, onClose } = props
+CellRendererName.propTypes = {
+  item: PropTypes.object.isRequired,
+  itemLabelFunction: PropTypes.func.isRequired,
+}
+
+const ItemsView = (props) => {
+  const {
+    columns,
+    items,
+    itemLink,
+    itemLabelFunction,
+    selectedItemUuid,
+    canSelect,
+    canDelete,
+    readOnly,
+    className,
+    onAdd,
+    onSelect,
+    onEdit,
+    onDelete,
+    onClose,
+  } = props
+
   const i18n = useI18n()
 
   return (
     <div className={`items${className ? ` ${className}` : ''}`}>
-      <ItemsTable {...props} />
+      <ItemsTable
+        columns={columns}
+        items={items}
+        itemLink={itemLink}
+        itemLabelFunction={itemLabelFunction}
+        selectedItemUuid={selectedItemUuid}
+        canSelect={canSelect}
+        canDelete={canDelete}
+        readOnly={readOnly}
+        onAdd={onAdd}
+        onSelect={onSelect}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
 
       {onClose && (
         <div className="items__footer">
-          <button className="btn" onClick={() => onClose()}>
+          <button type="button" className="btn" onClick={onClose}>
             {i18n.t('common.close')}
           </button>
         </div>
@@ -45,17 +80,38 @@ const ItemsView = props => {
   )
 }
 
+ItemsView.propTypes = {
+  columns: PropTypes.arrayOf(Object),
+  items: PropTypes.array,
+  itemLink: PropTypes.string,
+  itemLabelFunction: PropTypes.func,
+  selectedItemUuid: PropTypes.string,
+  canSelect: PropTypes.bool,
+  canDelete: PropTypes.func,
+  readOnly: PropTypes.bool,
+  className: PropTypes.string,
+  onAdd: PropTypes.func,
+  onSelect: PropTypes.func,
+  onEdit: PropTypes.func,
+  onDelete: PropTypes.func,
+  onClose: PropTypes.func,
+}
+
 ItemsView.defaultProps = {
   columns: [new ItemsColumn('common.name', CellRendererName, 'name')],
   items: [],
   itemLink: null,
+  itemLabelFunction: null,
   selectedItemUuid: null,
   canSelect: false,
-  canDelete: false,
+  canDelete: null,
   readOnly: true,
   className: null,
+  onAdd: null,
   onSelect: null,
+  onEdit: null,
   onDelete: null,
+  onClose: null,
 }
 
 export default ItemsView

--- a/webapp/views/App/views/Analysis/Analysis.js
+++ b/webapp/views/App/views/Analysis/Analysis.js
@@ -5,7 +5,6 @@ import { useHistory } from 'react-router'
 import { appModules, appModuleUri, analysisModules } from '@webapp/app/appModules'
 
 import ModuleSwitch from '@webapp/components/moduleSwitch'
-import CategoriesView from '@webapp/loggedin/surveyViews/categories/categoriesView'
 import CategoryView from '@webapp/loggedin/surveyViews/category/categoryView'
 import NodeDefDetails from '@webapp/components/survey/NodeDefDetails'
 import SurveyDefsLoader from '@webapp/components/survey/SurveyDefsLoader'
@@ -40,11 +39,6 @@ const Analysis = () => {
           {
             component: NodeDefDetails,
             path: `${appModuleUri(analysisModules.nodeDef)}:nodeDefUuid/`,
-          },
-          {
-            component: CategoriesView,
-            path: appModuleUri(analysisModules.categories),
-            props: { analysis: true },
           },
           {
             component: CategoryView,


### PR DESCRIPTION
Categories View is always shown in a PanelRight
When adding a new category, a other PanelRight is shown. 
If this works we can apply the same logic to TaxonProps. 