### PR TITLE
Select step should reset  calculations

### DIFF
--- a/webapp/views/App/views/Analysis/Chain/store/actions/step/useSelect.js
+++ b/webapp/views/App/views/Analysis/Chain/store/actions/step/useSelect.js
@@ -25,7 +25,9 @@ export const useSelect = ({ setState }) => {
             : Chain.dissocProcessingStepTemporary(chainUpdated)
         ),
         State.assocStep(step),
-        State.assocStepEdit(step)
+        State.assocStepEdit(step),
+        State.dissocCalculation,
+        State.dissocCalculationEdit
       )(state)
     )
   }


### PR DESCRIPTION
This is not a current issue on the sprint but I noticed that if we are into a step with some calculation opened if we chose another step we had an inconsistency