### PR TITLE
add file props

### DIFF
--- a/core/i18n/resources/en.js
+++ b/core/i18n/resources/en.js
@@ -456,6 +456,17 @@ $t(common.cantUndoWarning)`,
     decimalProps: {
       maxNumberDecimalDigits: 'Max number of decimal digits',
     },
+    fileProps: {
+      numberOfFiles: 'Go to Validations to change the Min. and Max. number of files.',
+      maxFileSize: 'Max. file size (Mb)',
+      fileType: 'File type',
+      fileTypes: {
+        image: 'Image',
+        video: 'Video',
+        audio: 'Audio',
+        other: 'Other',
+      },
+    },
     textProps: {
       textTransform: 'Text transform',
       textTransformTypes: {

--- a/core/survey/nodeDef.js
+++ b/core/survey/nodeDef.js
@@ -63,6 +63,10 @@ export const propKeys = {
   parentCodeDefUuid: 'parentCodeDefUuid',
   // Taxon
   taxonomyUuid: 'taxonomyUuid',
+
+  // File
+  maxFileSize: 'maxFileSize',
+  fileType: 'fileType',
 }
 
 export const textTransformValues = {
@@ -75,6 +79,13 @@ export const textTransformValues = {
 export const booleanLabelValues = {
   trueFalse: 'trueFalse',
   yesNo: 'yesNo',
+}
+
+export const fileTypeValues = {
+  image: 'image',
+  video: 'video',
+  audio: 'audio',
+  other: 'other',
 }
 
 export const keysPropsAdvanced = {
@@ -137,6 +148,11 @@ export const getTextTransformFunction = (nodeDef) =>
   TextUtils.transform({ transformFunction: getTextTransform(nodeDef) })
 
 export const getMaxNumberDecimalDigits = (nodeDef) => Number(getProp(propKeys.maxNumberDecimalDigits, 6)(nodeDef))
+
+// File
+export const isNumberOfFilesEnabled = isMultiple
+export const getMaxFileSize = (nodeDef) => Number(getProp(propKeys.maxFileSize)(nodeDef))
+export const getFileType = getProp(propKeys.fileType, fileTypeValues.other)
 
 export const getLabelValue = getProp(propKeys.labelValue, booleanLabelValues.trueFalse)
 export const isBooleanLabelYesNo = (nodeDef) =>

--- a/webapp/components/survey/NodeDefDetails/BasicProps/BasicProps.js
+++ b/webapp/components/survey/NodeDefDetails/BasicProps/BasicProps.js
@@ -24,6 +24,7 @@ import CodeProps from '../CodeProps'
 import TaxonProps from '../TaxonProps'
 import DecimalProps from '../DecimalProps'
 import BooleanProps from '../BooleanProps'
+import FileProps from '../FileProps'
 
 const BasicProps = (props) => {
   const { state, Actions, editingFromDesigner } = props
@@ -94,6 +95,8 @@ const BasicProps = (props) => {
           />
         </FormItem>
       )}
+
+      {NodeDef.isFile(nodeDef) && <FileProps state={state} Actions={Actions} />}
 
       {displayAsEnabled && editingFromDesigner && (
         <FormItem label={i18n.t('nodeDefEdit.basicProps.displayAs')}>

--- a/webapp/components/survey/NodeDefDetails/FileProps.js
+++ b/webapp/components/survey/NodeDefDetails/FileProps.js
@@ -1,0 +1,86 @@
+import React, { useCallback, useEffect } from 'react'
+import PropTypes from 'prop-types'
+
+import * as A from '@core/arena'
+
+import { useI18n } from '@webapp/store/system'
+import { FormItem, Input } from '@webapp/components/form/Input'
+import ButtonGroup from '@webapp/components/form/buttonGroup'
+
+import * as NodeDef from '@core/survey/nodeDef'
+
+import { State } from './store'
+
+const fileTypes = ({ i18n }) => [
+  {
+    key: NodeDef.fileTypeValues.image,
+    label: i18n.t('nodeDefEdit.fileProps.fileTypes.image'),
+  },
+  {
+    key: NodeDef.fileTypeValues.video,
+    label: i18n.t('nodeDefEdit.fileProps.fileTypes.video'),
+  },
+  {
+    key: NodeDef.fileTypeValues.audio,
+    label: i18n.t('nodeDefEdit.fileProps.fileTypes.audio'),
+  },
+  {
+    key: NodeDef.fileTypeValues.other,
+    label: i18n.t('nodeDefEdit.fileProps.fileTypes.other'),
+  },
+]
+
+const FileProps = (props) => {
+  const { state, Actions } = props
+
+  const i18n = useI18n()
+
+  const nodeDef = State.getNodeDef(state)
+
+  const selectFileType = useCallback(
+    (value) => {
+      Actions.setProp({ state, key: NodeDef.propKeys.fileType, value })
+    },
+    [state]
+  )
+
+  useEffect(() => {
+    if (A.isEmpty(NodeDef.getFileType(nodeDef))) {
+      selectFileType(NodeDef.fileTypeValues.other)
+    }
+  }, [])
+
+  return (
+    <>
+      {NodeDef.isNumberOfFilesEnabled(nodeDef) && (
+        <FormItem label="">
+          <p>{i18n.t('nodeDefEdit.fileProps.numberOfFiles')}</p>
+        </FormItem>
+      )}
+
+      <FormItem label={i18n.t('nodeDefEdit.fileProps.maxFileSize')}>
+        <Input
+          disabled={false}
+          placeholder={i18n.t('nodeDefEdit.fileProps.maxFileSize')}
+          value={NodeDef.getMaxFileSize(nodeDef)}
+          type="number"
+          onChange={(value) => Actions.setProp({ state, key: NodeDef.propKeys.maxFileSize, value })}
+        />
+      </FormItem>
+      <FormItem label={i18n.t('nodeDefEdit.fileProps.fileType')}>
+        <ButtonGroup
+          selectedItemKey={NodeDef.getFileType(nodeDef)}
+          onChange={selectFileType}
+          items={fileTypes({ i18n })}
+        />
+      </FormItem>
+    </>
+  )
+}
+
+FileProps.propTypes = {
+  state: PropTypes.object.isRequired,
+  Actions: PropTypes.object.isRequired,
+}
+
+export default FileProps

--- a/webapp/components/survey/SurveyForm/nodeDefs/nodeDefUIProps.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/nodeDefUIProps.js
@@ -101,7 +101,7 @@ const propsUI = {
   [file]: {
     component: NodeDefFile,
     icon: <span className="icon icon-file-picture icon-left" />,
-    validations: false,
+    validations: true,
   },
 
   [entity]: {


### PR DESCRIPTION
Resolves #1126 

- add REQUIRED checkbox
This required is added by the Validation tab when the file is not multiple

- when MULTIPLE true: add minimum and maximum number of items
These fields are added into the Validation tab when the file is multiple

- Max. file size (Mb) (optional. This may be required by Arena Mobile)
Field added into the basic tab

- File type (Image | Video | Audio | Other). This will be required by Arena Mobile.
Field added into the basic tab

![Captura de pantalla 2020-11-10 a las 18 17 44](https://user-images.githubusercontent.com/11272068/98708069-0a919b00-2381-11eb-8e57-1b2753ed24bf.png)
![Captura de pantalla 2020-11-10 a las 18 17 55](https://user-images.githubusercontent.com/11272068/98708086-0feee580-2381-11eb-93f0-3efdf312a031.png)
![Captura de pantalla 2020-11-10 a las 18 18 05](https://user-images.githubusercontent.com/11272068/98708101-154c3000-2381-11eb-93eb-6a159564c839.png)
![Captura de pantalla 2020-11-10 a las 18 18 13](https://user-images.githubusercontent.com/11272068/98708114-19784d80-2381-11eb-89b7-31634a5fea2c.png)
