### PR TITLE
Fixed error importing Collect survey categories (do not camelize nested props)

### DIFF
--- a/core/arena/camelize.js
+++ b/core/arena/camelize.js
@@ -1,0 +1,31 @@
+const _camelCase = (str) => str.replace(/[_.-](\w|$)/g, (_, x) => x.toUpperCase())
+
+const _walk = ({ object, skip = [] }) => {
+  if (!object || !(object instanceof Object) || object instanceof Date || object instanceof RegExp) {
+    return object
+  }
+  if (Array.isArray(object)) {
+    return object.map(_walk)
+  }
+  return Object.entries(object).reduce((objAcc, [key, value]) => {
+    const skipped = skip.includes(key)
+    const keyTransformed = skipped ? key : _camelCase(key)
+    const valueTranformed = skipped ? value : _walk({ object: value })
+    return { ...objAcc, [keyTransformed]: valueTranformed }
+  }, {})
+}
+
+/**
+ * Recursively transform the keys of the specified object to camel-case.
+ *
+ * @param {object} [params={}] - The camelize parameters.
+ * @param {Array} [params.skip=[]] - An optional list of keys to skip.
+ *
+ * @returns {any} - The object with keys in camel case or the value in camel case.
+ */
+export const camelize = ({ skip = [] } = {}) => (object) => {
+  if (object instanceof String) {
+    return _camelCase(object)
+  }
+  return _walk({ object, skip })
+}

--- a/core/arena/camelize.js
+++ b/core/arena/camelize.js
@@ -5,7 +5,7 @@ const _walk = ({ object, skip = [] }) => {
     return object
   }
   if (Array.isArray(object)) {
-    return object.map(_walk)
+    return object.map((item) => _walk({ object: item }))
   }
   return Object.entries(object).reduce((objAcc, [key, value]) => {
     const skipped = skip.includes(key)

--- a/core/arena/camelizePartial.js
+++ b/core/arena/camelizePartial.js
@@ -3,8 +3,9 @@ import { _camelizePartial } from './internal/_camelizePartial'
 /**
  * Recursively transform the keys of the specified object to camel-case.
  *
- * @param {!object} object - The object or value to transform.
+ * @param {!object} [params={}] - The camelize parameters.
+ * @param {Array} [params.skip=[]] - An optional list of keys to skip.
  *
  * @returns {any} - The object with keys in camel case or the value in camel case.
  */
-export const camelize = (object) => _camelizePartial({}, object)
+export const camelizePartial = _camelizePartial

--- a/core/arena/index.js
+++ b/core/arena/index.js
@@ -1,4 +1,5 @@
 export { assoc } from './assoc'
+export { camelize } from './camelize'
 export { dissoc } from './dissoc'
 export { identity } from './identity'
 export { isEmpty } from './isEmpty'

--- a/core/arena/index.js
+++ b/core/arena/index.js
@@ -1,5 +1,6 @@
 export { assoc } from './assoc'
 export { camelize } from './camelize'
+export { camelizePartial } from './camelizePartial'
 export { dissoc } from './dissoc'
 export { identity } from './identity'
 export { isEmpty } from './isEmpty'

--- a/core/arena/internal/_camelizePartial.js
+++ b/core/arena/internal/_camelizePartial.js
@@ -1,0 +1,33 @@
+import { _curry2 } from './_curry2'
+
+const _camelCase = (str) => str.replace(/[_.-](\w|$)/g, (_, x) => x.toUpperCase())
+
+const _walk = ({ object, skip = [] }) => {
+  if (!object || !(object instanceof Object) || object instanceof Date || object instanceof RegExp) {
+    return object
+  }
+  if (Array.isArray(object)) {
+    return object.map((item) => _walk({ object: item }))
+  }
+  return Object.entries(object).reduce((objAcc, [key, value]) => {
+    const skipped = skip.includes(key)
+    const keyTransformed = skipped ? key : _camelCase(key)
+    const valueTranformed = skipped ? value : _walk({ object: value })
+    return { ...objAcc, [keyTransformed]: valueTranformed }
+  }, {})
+}
+
+/**
+ * Recursively transform the keys of the specified object to camel-case.
+ *
+ * @param {object} [params={}] - The camelize parameters.
+ * @param {Array} [params.skip=[]] - An optional list of keys to skip.
+ *
+ * @returns {any} - The object with keys in camel case or the value in camel case.
+ */
+export const _camelizePartial = _curry2(({ skip = [] } = {}, object) => {
+  if (object instanceof String) {
+    return _camelCase(object)
+  }
+  return _walk({ object, skip })
+})

--- a/server/db/utils/mergeProps.js
+++ b/server/db/utils/mergeProps.js
@@ -2,7 +2,7 @@ export const mergeProps = ({ draft = false } = {}) => (row) => {
   if (!row) {
     return null
   }
-  const { props, propsDraft, ...rest } = row
+  const { props, props_draft: propsDraft, ...rest } = row
   const propsUpdate = draft ? { ...props, ...propsDraft } : props
   return { ...rest, props: propsUpdate }
 }

--- a/server/db/utils/transformCallback.js
+++ b/server/db/utils/transformCallback.js
@@ -15,7 +15,7 @@ export const transformCallback = (row, draft = false, assocPublishedDraft = fals
   return A.pipe(
     // Assoc published and draft properties based on props
     (rowCurrent) => (assocPublishedDraft ? _assocPublishedDraft(rowCurrent) : rowCurrent),
-    A.camelize({ skip: ['validation', 'props', 'props_draft'] }),
+    A.camelizePartial({ skip: ['validation', 'props', 'props_draft'] }),
     mergeProps({ draft })
   )(row)
 }

--- a/server/db/utils/transformCallback.js
+++ b/server/db/utils/transformCallback.js
@@ -1,30 +1,21 @@
-import * as R from 'ramda'
-import * as camelize from 'camelize'
-
+import * as A from '../../../core/arena'
 import { mergeProps } from './mergeProps'
 
 const _assocPublishedDraft = (row) => ({
   ...row,
-  published: !R.isEmpty(row.props),
-  draft: !R.isEmpty(row.props_draft),
+  published: !A.isEmpty(row.props),
+  draft: !A.isEmpty(row.props_draft),
 })
 
-const _camelize = ({ skippedProps = [] }) => (obj) =>
-  Object.entries(obj).reduce((accObj, [propName, value]) => {
-    const propNameCamelCase = camelize(propName)
-    const valueTransformed = skippedProps.includes(propName) || !(value instanceof Object) ? value : camelize(value)
-    return { ...accObj, [propNameCamelCase]: valueTransformed }
-  }, {})
-
 export const transformCallback = (row, draft = false, assocPublishedDraft = false) => {
-  if (R.isNil(row)) {
+  if (A.isNull(row)) {
     return null
   }
 
-  return R.pipe(
+  return A.pipe(
     // Assoc published and draft properties based on props
     (rowCurrent) => (assocPublishedDraft ? _assocPublishedDraft(rowCurrent) : rowCurrent),
-    _camelize({ skippedProps: ['validation', 'props', 'props_draft'] }),
+    A.camelize({ skip: ['validation', 'props', 'props_draft'] }),
     mergeProps({ draft })
   )(row)
 }

--- a/test/unit/tests/006A.camelize.js
+++ b/test/unit/tests/006A.camelize.js
@@ -23,6 +23,22 @@ const tests = [
     object: { first_prop: 1, second_prop: 2, third_prop: { third_prop_a: 11, third_prop_b: 12 } },
     expected: { firstProp: 1, secondProp: 2, thirdProp: { thirdPropA: 11, thirdPropB: 12 } },
   },
+  {
+    object: {
+      first_prop: 1,
+      second_prop: [
+        { arr_prop_1: 11, arr_prop_2: 12 },
+        { arr_prop_1: 21, arr_prop_2: 22 },
+      ],
+    },
+    expected: {
+      firstProp: 1,
+      secondProp: [
+        { arrProp1: 11, arrProp2: 12 },
+        { arrProp1: 21, arrProp2: 22 },
+      ],
+    },
+  },
   // complex objects (skip keys)
   {
     object: { first_prop: 1, second_prop: 2, third_prop: { third_prop_a: 11, third_prop_b: 12 } },

--- a/test/unit/tests/006A.camelize.js
+++ b/test/unit/tests/006A.camelize.js
@@ -1,0 +1,41 @@
+import * as A from '@core/arena'
+
+const now = new Date()
+
+const tests = [
+  // null/undefined values
+  { object: null, expected: null },
+  { object: undefined, expected: undefined },
+  // numeric values
+  { object: 1, expected: 1 },
+  // data values
+  { object: now, expected: now },
+  // test empty values
+  { object: {}, expected: {} },
+  // simple objects
+  { object: { a: 1 }, expected: { a: 1 } },
+  { object: { firstProp: 1 }, expected: { firstProp: 1 } },
+  { object: { first_prop: 1 }, expected: { firstProp: 1 } },
+  { object: { first_prop: 1, second_prop: 2 }, expected: { firstProp: 1, secondProp: 2 } },
+  { object: { firstProp: 1, second_prop: 2 }, expected: { firstProp: 1, secondProp: 2 } },
+  // complex objects
+  {
+    object: { first_prop: 1, second_prop: 2, third_prop: { third_prop_a: 11, third_prop_b: 12 } },
+    expected: { firstProp: 1, secondProp: 2, thirdProp: { thirdPropA: 11, thirdPropB: 12 } },
+  },
+  // complex objects (skip keys)
+  {
+    object: { first_prop: 1, second_prop: 2, third_prop: { third_prop_a: 11, third_prop_b: 12 } },
+    skip: ['third_prop'],
+    expected: { firstProp: 1, secondProp: 2, third_prop: { third_prop_a: 11, third_prop_b: 12 } },
+  },
+]
+
+describe('A.camelize', () => {
+  tests.forEach(({ object, expected, skip = [] }) => {
+    it(`${JSON.stringify(object)} ->  ${JSON.stringify(expected)}`, () => {
+      const valueCamelized = A.camelize({ skip })(object)
+      expect(valueCamelized).toEqual(expected)
+    })
+  })
+})

--- a/test/unit/tests/006A.camelize.js
+++ b/test/unit/tests/006A.camelize.js
@@ -50,7 +50,7 @@ const tests = [
 describe('A.camelize', () => {
   tests.forEach(({ object, expected, skip = [] }) => {
     it(`${JSON.stringify(object)} ->  ${JSON.stringify(expected)}`, () => {
-      const valueCamelized = A.camelize({ skip })(object)
+      const valueCamelized = A.camelizePartial({ skip }, object)
       expect(valueCamelized).toEqual(expected)
     })
   })


### PR DESCRIPTION
Fixes #1266
The fix is small but can have side effects on the whole application.
As far as I have seen, everything seems to work fine.
Since the amount code of camelize is very small, should we create our own A.camelize function that accepts a list of properties to skip? Or should we suggest this change to the developer and open a pull request?! I vote for the 2nd...