### PR TITLE
Add 409 as status code when user is already invited

### DIFF
--- a/core/systemError.js
+++ b/core/systemError.js
@@ -1,11 +1,33 @@
+export const StatusCodes = {
+  CONTINUE: 100,
+
+  OK: 200,
+  CREATED: 201,
+  ACCEPTED: 202,
+  NO_CONTENT: 204,
+
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+
+  INTERNAL_SERVER_ERROR: 500,
+  NOT_IMPLEMENTED: 501,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504,
+}
+
 export default class SystemError extends Error {
-  constructor(key, params) {
+  constructor(key, params, statusCode = StatusCodes.INTERNAL_SERVER_ERROR) {
     super(key)
 
     this.name = 'SystemError'
 
     this._key = key
     this._params = params
+    this._statusCode = statusCode
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (Error.captureStackTrace) {
@@ -19,5 +41,9 @@ export default class SystemError extends Error {
 
   get params() {
     return this._params
+  }
+
+  get statusCode() {
+    return this._statusCode
   }
 }

--- a/server/modules/user/service/userService.js
+++ b/server/modules/user/service/userService.js
@@ -8,7 +8,7 @@ import * as UserInvite from '@core/user/userInvite'
 import * as AuthGroup from '@core/auth/authGroup'
 import * as Authorizer from '@core/auth/authorizer'
 
-import SystemError from '@core/systemError'
+import SystemError, { StatusCodes } from '@core/systemError'
 import UnauthorizedError from '@server/utils/unauthorizedError'
 import * as Mailer from '@server/utils/mailer'
 import * as SurveyManager from '../../survey/manager/surveyManager'
@@ -36,7 +36,11 @@ const _checkUserCanBeInvited = (userToInvite, surveyUuid) => {
   const hasRoleInSurvey = authGroups.some((g) => AuthGroup.getSurveyUuid(g) === surveyUuid)
 
   if (!User.hasAccepted(userToInvite)) {
-    throw new SystemError('appErrors.userHasPendingInvitation', { email: User.getEmail(userToInvite) })
+    throw new SystemError(
+      'appErrors.userHasPendingInvitation',
+      { email: User.getEmail(userToInvite) },
+      StatusCodes.CONFLICT
+    )
   } else if (hasRoleInSurvey) {
     throw new SystemError('appErrors.userHasRole')
   } else if (User.isSystemAdmin(userToInvite)) {

--- a/server/utils/response.js
+++ b/server/utils/response.js
@@ -1,7 +1,7 @@
 import Archiver from 'archiver'
 
 import * as FileUtils from '@server/utils/file/fileUtils'
-import SystemError from '@core/systemError'
+import SystemError, { StatusCodes } from '@core/systemError'
 import UnauthorizedError from './unauthorizedError'
 
 const status = {
@@ -24,11 +24,11 @@ const _getErr = ({ key, params }) => ({
 
 export const sendErr = (res, err) => {
   if (err instanceof UnauthorizedError) {
-    res.status(403).json(_getErr(err))
+    res.status(StatusCodes.FORBIDDEN).json(_getErr(err))
   } else if (err instanceof SystemError) {
-    res.status(500).json(_getErr(err))
+    res.status(err.statusCode).json(_getErr(err))
   } else {
-    res.status(500).json(
+    res.status(err.statusCode).json(
       _getErr({
         key: 'appErrors.generic',
         params: { text: `Could not serve: ${err.toString()}` },


### PR DESCRIPTION
## Related Issue

Resolves #1382 

## Brief description of the changes proposed an/or how the issue(s) has(have) been solved.

Before we sent always 500 as a status code in every error, the idea behind this PR is to be more explicit about what is the nature of the error.

An initial StatusCode dictionary was added but could be better replace this for some library, like this: https://www.npmjs.com/package/http-status-codes.

1.  Now the SystemErrors can have a custom StatusCode
2. This Status Codes are defined in a dictionary
3. And this StatusCode is going to be returned into the error response
4. The first Error that implements a different StatusCode than 500 is 'appErrors.userHasPendingInvitation' which instead of being INTERNAL_SERVER_ERROR should be CONFLICT


## How has this been tested

Invite a user 2 times and see the statuscode error
Try to have other error and ensure that all still works


##### Do you consider this PR needs further testing?
- [X] No
- [ ] Yes

## Types of changes
- [ ] Docs change 
- [X] Refactoring 
- [ ] Dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Disclaimer
The dictionary could be changed