### PR TITLE
NodeDefExpression: added parent() function

### DIFF
--- a/core/expressionParser/expression.js
+++ b/core/expressionParser/expression.js
@@ -49,7 +49,6 @@ export const evalExpr = ({ expr, ctx }) => Evaluator.evalExpression(expr, ctx)
 export const evalString = (query, ctx) => evalExpr({ expr: fromString(query), ctx })
 
 export const { isValid } = ExpressionUtils
-export const { getExpressionIdentifiers } = Evaluator
 
 // ====== Type checking
 

--- a/core/expressionParser/helpers/evaluator.js
+++ b/core/expressionParser/helpers/evaluator.js
@@ -203,15 +203,3 @@ export const evalExpression = (expr, ctx = {}) => {
 
   return fn(expr, ctx)
 }
-
-export const getExpressionIdentifiers = (expr) => {
-  const identifiers = []
-  const evaluators = {
-    [types.Identifier]: (exp) => {
-      identifiers.push(R.prop('name')(exp))
-    },
-  }
-
-  evalExpression(expr, { evaluators })
-  return R.uniq(identifiers)
-}

--- a/core/expressionParser/helpers/functionImplementations.js
+++ b/core/expressionParser/helpers/functionImplementations.js
@@ -14,6 +14,7 @@ export const functionImplementations = {
   [functionNames.min]: Math.min,
   [functionNames.max]: Math.max,
   [functionNames.now]: () => DateUtils.nowFormatDefault(),
+  [functionNames.parent]: () => null,
   [functionNames.pow]: (base, exponent) => base ** exponent,
   [functionNames.sum]: A.identity,
 }

--- a/core/expressionParser/helpers/functions.js
+++ b/core/expressionParser/helpers/functions.js
@@ -9,6 +9,7 @@ export const functionNames = {
   max: 'max',
   min: 'min',
   now: 'now',
+  parent: 'parent',
   pow: 'pow',
   sum: 'sum',
 }
@@ -31,6 +32,7 @@ export const functions = {
   [functionNames.max]: { minArity: 1, maxArity: -1 },
   [functionNames.min]: { minArity: 1, maxArity: -1 },
   [functionNames.now]: { minArity: 0, maxArity: 0 },
+  [functionNames.parent]: { minArity: 1, maxArity: 1, evaluateArgsToNodes: true },
   [functionNames.pow]: { minArity: 2 },
   [functionNames.sum]: { minArity: 1, maxArity: 1 },
 }

--- a/core/i18n/resources/en.js
+++ b/core/i18n/resources/en.js
@@ -446,6 +446,7 @@ $t(common.cantUndoWarning)`,
       max: 'Take the maximum of the arguments',
       min: 'Take the minimum of the arguments',
       now: 'Returns the current date or time',
+      parent: 'Returns the parent entity of the specified node',
       pow: 'Raise a number X to the power P',
       // SQL functions
       avg: 'Returns the average value of a numeric variable',

--- a/core/record/recordExpressionParser/memberEval.js
+++ b/core/record/recordExpressionParser/memberEval.js
@@ -9,7 +9,7 @@ export const memberEval = (expr, ctx) => {
 
   const objectEval = Expression.evalExpr({ expr: object, ctx })
 
-  if (objectEval && !R.isEmpty(objectEval)) {
+  if (objectEval) {
     if (Expression.isIdentifier(property)) {
       const propertyName = Expression.getName(property)
       if (NodeNativeProperties.isNativeProperty(propertyName)) {

--- a/core/record/recordExpressionParser/memberEval.js
+++ b/core/record/recordExpressionParser/memberEval.js
@@ -1,32 +1,28 @@
-import * as R from 'ramda'
-
 import * as Expression from '@core/expressionParser/expression'
 
 import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
 
 export const memberEval = (expr, ctx) => {
-  const { object, property } = expr
+  const { object, property, computed } = expr
 
   const objectEval = Expression.evalExpr({ expr: object, ctx })
-
-  if (objectEval) {
-    if (Expression.isIdentifier(property)) {
-      const propertyName = Expression.getName(property)
-      if (NodeNativeProperties.isNativeProperty(propertyName)) {
-        // property is a native property of the node
-        return NodeNativeProperties.evalProperty({ node: objectEval, propertyName })
-      }
-    }
-    // evaluate property moving the context node to the evaluated object
-    const propertyEval = Expression.evalExpr({ expr: property, ctx: { ...ctx, node: objectEval } })
-
-    if (Expression.isLiteral(property) && R.is(Array)(objectEval) && R.is(Number)(propertyEval)) {
-      // property is the index of a multiple node
-      return objectEval[propertyEval]
-    }
-
-    // property is a child of the "object" node
-    return propertyEval
+  if (!objectEval) {
+    return null
   }
-  return null
+  if (!computed && Expression.isIdentifier(property)) {
+    const propertyName = Expression.getName(property)
+    if (NodeNativeProperties.isNativeProperty(propertyName)) {
+      // property is a native property of the node
+      return NodeNativeProperties.evalProperty({ node: objectEval, propertyName })
+    }
+  }
+
+  if (computed) {
+    // property is the index of a multiple node
+    const propertyEval = Expression.evalExpr({ expr: property, ctx })
+    return objectEval[propertyEval]
+  }
+  // property is a child of the "object" node
+  // evaluate property moving the context node to the evaluated object
+  return Expression.evalExpr({ expr: property, ctx: { ...ctx, node: objectEval } })
 }

--- a/core/record/recordExpressionParser/recordEpressionFunctions.js
+++ b/core/record/recordExpressionParser/recordEpressionFunctions.js
@@ -17,4 +17,10 @@ export const recordExpressionFunctions = ({ record }) => ({
     const children = Record.getNodeChildrenByDefUuid(nodeParent, Node.getNodeDefUuid(node))(record)
     return children.findIndex(Node.isEqual(node))
   },
+  [Expression.functionNames.parent]: (node) => {
+    if (!node || Node.isRoot(node)) {
+      return null
+    }
+    return Record.getParentNode(node)(record)
+  },
 })

--- a/core/survey/_survey/surveyDependencies.js
+++ b/core/survey/_survey/surveyDependencies.js
@@ -27,25 +27,33 @@ const addDeps = (survey, nodeDef, type, expressions) => (graph) => {
 
   const referencedNodeDefs = {}
   expressions.forEach((nodeDefExpr) => {
-    Object.assign(
-      referencedNodeDefs,
-      NodeDefExpressionValidator.findReferencedNodeDefs({
-        survey,
-        nodeDef,
-        exprString: NodeDefExpression.getExpression(nodeDefExpr),
-        isContextParent,
-        selfReferenceAllowed,
-      })
-    )
-    Object.assign(
-      NodeDefExpressionValidator.findReferencedNodeDefs({
-        survey,
-        nodeDef,
-        exprString: NodeDefExpression.getApplyIf(nodeDefExpr),
-        isContextParent,
-        selfReferenceAllowed,
-      })
-    )
+    try {
+      Object.assign(
+        referencedNodeDefs,
+        NodeDefExpressionValidator.findReferencedNodeDefs({
+          survey,
+          nodeDef,
+          exprString: NodeDefExpression.getExpression(nodeDefExpr),
+          isContextParent,
+          selfReferenceAllowed,
+        })
+      )
+    } catch (e) {
+      // TODO ignore it?
+    }
+    try {
+      Object.assign(
+        NodeDefExpressionValidator.findReferencedNodeDefs({
+          survey,
+          nodeDef,
+          exprString: NodeDefExpression.getApplyIf(nodeDefExpr),
+          isContextParent,
+          selfReferenceAllowed,
+        })
+      )
+    } catch (e) {
+      // TODO ignore it?
+    }
   })
 
   Object.values(referencedNodeDefs).forEach((nodeDefRef) => {

--- a/core/survey/_survey/surveyDependencies.js
+++ b/core/survey/_survey/surveyDependencies.js
@@ -3,49 +3,79 @@ import * as R from 'ramda'
 import * as ObjectUtils from '@core/objectUtils'
 
 import * as NodeDefExpression from '../nodeDefExpression'
+import * as NodeDefExpressionValidator from '../nodeDefExpressionValidator'
 import * as NodeDef from '../nodeDef'
 import * as SurveyNodeDefs from './surveyNodeDefs'
+import * as SurveyDependencyTypes from './surveyDependencyTypes'
+
+export { dependencyTypes } from './surveyDependencyTypes'
 
 const keys = {
   dependencyGraph: 'dependencyGraph',
 }
 
-export const dependencyTypes = {
-  defaultValues: 'defaultValues',
-  applicable: 'applicable',
-  validations: 'validations',
-  formula: 'formula',
-}
-
 const _getDeps = (type, nodeDefUuid) => R.pathOr([], [type, nodeDefUuid])
 
-const _addDep = (type, nodeDefUuid, nodeDefDepUuid) => graph =>
-  R.pipe(_getDeps(type, nodeDefUuid), R.append(nodeDefDepUuid), dep =>
-    ObjectUtils.setInPath([type, nodeDefUuid], dep)(graph),
+const _addDep = (type, nodeDefUuid, nodeDefDepUuid) => (graph) =>
+  R.pipe(_getDeps(type, nodeDefUuid), R.append(nodeDefDepUuid), (dep) =>
+    ObjectUtils.setInPath([type, nodeDefUuid], dep)(graph)
   )(graph)
 
-const addDeps = (survey, nodeDef, type, expressions) => graph => {
-  const refNames = NodeDefExpression.findReferencedNodeDefs(expressions)
+const addDeps = (survey, nodeDef, type, expressions) => (graph) => {
+  const isContextParent = SurveyDependencyTypes.isContextParentByDependencyType[type]
+  const selfReferenceAllowed = SurveyDependencyTypes.selfReferenceAllowedByDependencyType[type]
 
-  for (const refName of refNames) {
-    const nodeDefRef = SurveyNodeDefs.getNodeDefByName(refName)(survey)
-    graph = _addDep(type, NodeDef.getUuid(nodeDefRef), NodeDef.getUuid(nodeDef))(graph)
-  }
+  const referencedNodeDefs = {}
+  expressions.forEach((nodeDefExpr) => {
+    Object.assign(
+      referencedNodeDefs,
+      NodeDefExpressionValidator.findReferencedNodeDefs({
+        survey,
+        nodeDef,
+        exprString: NodeDefExpression.getExpression(nodeDefExpr),
+        isContextParent,
+        selfReferenceAllowed,
+      })
+    )
+    Object.assign(
+      NodeDefExpressionValidator.findReferencedNodeDefs({
+        survey,
+        nodeDef,
+        exprString: NodeDefExpression.getApplyIf(nodeDefExpr),
+        isContextParent,
+        selfReferenceAllowed,
+      })
+    )
+  })
+
+  Object.values(referencedNodeDefs).forEach((nodeDefRef) => {
+    _addDep(type, NodeDef.getUuid(nodeDefRef), NodeDef.getUuid(nodeDef))(graph)
+  })
 
   return graph
 }
 
 // ====== CREATE
-export const buildGraph = survey =>
+export const buildGraph = (survey) =>
   R.reduce(
     (graph, nodeDef) =>
       R.pipe(
-        addDeps(survey, nodeDef, dependencyTypes.defaultValues, NodeDef.getDefaultValues(nodeDef)),
-        addDeps(survey, nodeDef, dependencyTypes.applicable, NodeDef.getApplicable(nodeDef)),
-        addDeps(survey, nodeDef, dependencyTypes.validations, NodeDef.getValidationExpressions(nodeDef)),
+        addDeps(
+          survey,
+          nodeDef,
+          SurveyDependencyTypes.dependencyTypes.defaultValues,
+          NodeDef.getDefaultValues(nodeDef)
+        ),
+        addDeps(survey, nodeDef, SurveyDependencyTypes.dependencyTypes.applicable, NodeDef.getApplicable(nodeDef)),
+        addDeps(
+          survey,
+          nodeDef,
+          SurveyDependencyTypes.dependencyTypes.validations,
+          NodeDef.getValidationExpressions(nodeDef)
+        )
       )(graph),
     {},
-    SurveyNodeDefs.getNodeDefsArray(survey),
+    SurveyNodeDefs.getNodeDefsArray(survey)
   )
 
 export const getDependencyGraph = R.propOr({}, keys.dependencyGraph)
@@ -62,23 +92,26 @@ export const getNodeDefDependencies = (nodeDefUuid, dependencyType = null) =>
           (accDependents, graph) =>
             R.pipe(
               R.propOr([], nodeDefUuid),
-              R.ifElse(R.isEmpty, R.always(accDependents), R.concat(accDependents)),
+              R.ifElse(R.isEmpty, R.always(accDependents), R.concat(accDependents))
             )(graph),
-          [],
+          []
         ),
         R.flatten,
-        R.uniq,
+        R.uniq
       ),
       // Return dependents by dependency Type
-      R.pathOr([], [dependencyType, nodeDefUuid]),
-    ),
+      R.pathOr([], [dependencyType, nodeDefUuid])
+    )
   )
 
 /**
- * Returns true if nodeDefUuid is among the dependencies of the specified nodeDefSourceUuid.
+ * Determines if the specified nodeDefUuid is among the dependencies of the specified nodeDefSourceUuid.
  *
+ * @param {!string} nodeDefUuid - The uuid of the node definition to look for.
+ * @param {!string} nodeDefSourceUuid - The uuid of the node definition to use as source of the dependency.
+ * @returns {boolean} - True if the dependency if found, false otherwise.
  */
-export const isNodeDefDependentOn = (nodeDefUuid, nodeDefSourceUuid) => survey => {
+export const isNodeDefDependentOn = (nodeDefUuid, nodeDefSourceUuid) => (survey) => {
   if (nodeDefUuid === nodeDefSourceUuid) {
     return false
   }
@@ -98,7 +131,7 @@ export const isNodeDefDependentOn = (nodeDefUuid, nodeDefSourceUuid) => survey =
     visitedUuids.add(nodeDefUuidCurrent)
 
     const dependencies = getNodeDefDependencies(nodeDefUuidCurrent)(survey)
-    R.forEach(nodeDefUuidDependent => {
+    R.forEach((nodeDefUuidDependent) => {
       if (!visitedUuids.has(nodeDefUuidDependent)) {
         stack.push(nodeDefUuidDependent)
       }
@@ -109,7 +142,7 @@ export const isNodeDefDependentOn = (nodeDefUuid, nodeDefSourceUuid) => survey =
 }
 
 // UPDATE
-export const assocDependencyGraph = dependencyGraph => R.assoc(keys.dependencyGraph, dependencyGraph)
+export const assocDependencyGraph = (dependencyGraph) => R.assoc(keys.dependencyGraph, dependencyGraph)
 
-export const buildAndAssocDependencyGraph = survey =>
-  R.pipe(buildGraph, graph => assocDependencyGraph(graph)(survey))(survey)
+export const buildAndAssocDependencyGraph = (survey) =>
+  R.pipe(buildGraph, (graph) => assocDependencyGraph(graph)(survey))(survey)

--- a/core/survey/_survey/surveyDependencyTypes.js
+++ b/core/survey/_survey/surveyDependencyTypes.js
@@ -1,0 +1,20 @@
+export const dependencyTypes = {
+  defaultValues: 'defaultValues',
+  applicable: 'applicable',
+  validations: 'validations',
+  formula: 'formula',
+}
+
+export const isContextParentByDependencyType = {
+  [dependencyTypes.defaultValues]: false,
+  [dependencyTypes.applicable]: true,
+  [dependencyTypes.validations]: false,
+  [dependencyTypes.formula]: false,
+}
+
+export const selfReferenceAllowedByDependencyType = {
+  [dependencyTypes.defaultValues]: false,
+  [dependencyTypes.applicable]: false,
+  [dependencyTypes.validations]: true,
+  [dependencyTypes.formula]: false,
+}

--- a/core/survey/_surveyValidator/nodeDefExpressionsValidator.js
+++ b/core/survey/_surveyValidator/nodeDefExpressionsValidator.js
@@ -2,52 +2,42 @@ import * as R from 'ramda'
 
 import * as Validator from '@core/validation/validator'
 import * as Validation from '@core/validation/validation'
-import * as Survey from '@core/survey/survey'
 import * as NodeDef from '@core/survey/nodeDef'
 import * as NodeDefValidations from '@core/survey/nodeDefValidations'
 import * as NodeDefExpression from '@core/survey/nodeDefExpression'
 import * as ObjectUtils from '@core/objectUtils'
 import * as NodeDefExpressionValidator from '../nodeDefExpressionValidator'
-
-const isContextParentByDependencyType = {
-  [Survey.dependencyTypes.defaultValues]: false,
-  [Survey.dependencyTypes.applicable]: true,
-  [Survey.dependencyTypes.validations]: false,
-  [Survey.dependencyTypes.formula]: false,
-}
+import * as SurveyDependencyTypes from '../_survey/surveyDependencyTypes'
 
 const expressionsByDependencyTypeFns = {
-  [Survey.dependencyTypes.defaultValues]: NodeDef.getDefaultValues,
-  [Survey.dependencyTypes.applicable]: NodeDef.getApplicable,
-  [Survey.dependencyTypes.validations]: R.pipe(NodeDef.getValidations, NodeDefValidations.getExpressions),
-  [Survey.dependencyTypes.formula]: NodeDef.getFormula,
-}
-
-const selfReferenceAllowedByDependencyType = {
-  [Survey.dependencyTypes.defaultValues]: false,
-  [Survey.dependencyTypes.applicable]: false,
-  [Survey.dependencyTypes.validations]: true,
-  [Survey.dependencyTypes.formula]: false,
+  [SurveyDependencyTypes.dependencyTypes.defaultValues]: NodeDef.getDefaultValues,
+  [SurveyDependencyTypes.dependencyTypes.applicable]: NodeDef.getApplicable,
+  [SurveyDependencyTypes.dependencyTypes.validations]: R.pipe(
+    NodeDef.getValidations,
+    NodeDefValidations.getExpressions
+  ),
+  [SurveyDependencyTypes.dependencyTypes.formula]: NodeDef.getFormula,
 }
 
 const applyIfUniquenessByDependencyType = {
-  [Survey.dependencyTypes.defaultValues]: true,
-  [Survey.dependencyTypes.applicable]: false,
-  [Survey.dependencyTypes.validations]: false,
-  [Survey.dependencyTypes.formula]: false,
+  [SurveyDependencyTypes.dependencyTypes.defaultValues]: true,
+  [SurveyDependencyTypes.dependencyTypes.applicable]: false,
+  [SurveyDependencyTypes.dependencyTypes.validations]: false,
+  [SurveyDependencyTypes.dependencyTypes.formula]: false,
 }
 
 const errorKeyByDependencyType = {
-  [Survey.dependencyTypes.defaultValues]: Validation.messageKeys.nodeDefEdit.defaultValuesInvalid,
-  [Survey.dependencyTypes.applicable]: Validation.messageKeys.nodeDefEdit.applyIfInvalid,
-  [Survey.dependencyTypes.validations]: Validation.messageKeys.nodeDefEdit.validationsInvalid,
-  [Survey.dependencyTypes.formula]: Validation.messageKeys.nodeDefEdit.formulaInvalid,
+  [SurveyDependencyTypes.dependencyTypes.defaultValues]: Validation.messageKeys.nodeDefEdit.defaultValuesInvalid,
+  [SurveyDependencyTypes.dependencyTypes.applicable]: Validation.messageKeys.nodeDefEdit.applyIfInvalid,
+  [SurveyDependencyTypes.dependencyTypes.validations]: Validation.messageKeys.nodeDefEdit.validationsInvalid,
+  [SurveyDependencyTypes.dependencyTypes.formula]: Validation.messageKeys.nodeDefEdit.formulaInvalid,
 }
 
 const _validateExpressionProp = (survey, nodeDef, dependencyType) => async (propName, item) => {
   const exprString = R.pathOr(null, propName.split('.'), item)
-  const isContextParent = isContextParentByDependencyType[dependencyType]
-  const selfReferenceAllowed = selfReferenceAllowedByDependencyType[dependencyType]
+  const isContextParent = SurveyDependencyTypes.isContextParentByDependencyType[dependencyType]
+  const selfReferenceAllowed = SurveyDependencyTypes.selfReferenceAllowedByDependencyType[dependencyType]
+
   return exprString
     ? NodeDefExpressionValidator.validate({
         survey,

--- a/core/survey/nodeDefExpression.js
+++ b/core/survey/nodeDefExpression.js
@@ -7,8 +7,6 @@ import * as ValidationResult from '@core/validation/validationResult'
 import * as StringUtils from '@core/stringUtils'
 import * as ObjectUtils from '@core/objectUtils'
 
-import * as Expression from '@core/expressionParser/expression'
-
 export const keys = {
   placeholder: 'placeholder',
   expression: 'expression',
@@ -54,22 +52,6 @@ const assocProp = (propName, value) => R.pipe(R.assoc(propName, value), R.dissoc
 // ====== UTILS
 
 export const { isEqual } = ObjectUtils
-
-const extractNodeDefNames = (jsExpr = '') =>
-  StringUtils.isBlank(jsExpr) ? [] : Expression.getExpressionIdentifiers(Expression.fromString(jsExpr))
-
-export const findReferencedNodeDefs = (nodeDefExpressions) =>
-  R.pipe(
-    R.reduce(
-      (acc, nodeDefExpr) =>
-        R.pipe(
-          R.concat(extractNodeDefNames(getExpression(nodeDefExpr))),
-          R.concat(extractNodeDefNames(getApplyIf(nodeDefExpr)))
-        )(acc),
-      []
-    ),
-    R.uniq
-  )(nodeDefExpressions)
 
 // UPDATE
 export const assocExpression = (expression) => assocProp(keys.expression, expression)

--- a/core/survey/nodeDefExpressionValidator/identifierEval.js
+++ b/core/survey/nodeDefExpressionValidator/identifierEval.js
@@ -42,7 +42,10 @@ const _getReachableNodeDefs = (survey, nodeDefContext) => {
   return reachableNodeDefs
 }
 
-export const identifierEval = ({ survey, nodeDefCurrent, selfReferenceAllowed }) => (expr, ctx) => {
+export const identifierEval = ({ survey, nodeDefCurrent, selfReferenceAllowed, evaluateToNode = false }) => (
+  expr,
+  ctx
+) => {
   const { node: nodeDefContext } = ctx
 
   const nodeName = R.prop('name')(expr)
@@ -72,5 +75,5 @@ export const identifierEval = ({ survey, nodeDefCurrent, selfReferenceAllowed })
     throw new SystemError(Validation.messageKeys.expressions.circularDependencyError, { name: nodeName })
   }
 
-  return NodeDef.isEntity(def) || NodeDef.isMultiple(def) ? def : _getNodeValue(def)
+  return NodeDef.isEntity(def) || NodeDef.isMultiple(def) || evaluateToNode ? def : _getNodeValue(def)
 }

--- a/core/survey/nodeDefExpressionValidator/index.js
+++ b/core/survey/nodeDefExpressionValidator/index.js
@@ -1,1 +1,1 @@
-export { validate, findReferencedNodeDefs } from './nodeDefExpressionValidator'
+export { validate, findReferencedNodeDefs, findReferencedNodeDefLast } from './nodeDefExpressionValidator'

--- a/core/survey/nodeDefExpressionValidator/index.js
+++ b/core/survey/nodeDefExpressionValidator/index.js
@@ -1,1 +1,1 @@
-export { validate } from './nodeDefExpressionValidator'
+export { validate, findReferencedNodeDefs } from './nodeDefExpressionValidator'

--- a/core/survey/nodeDefExpressionValidator/memberEval.js
+++ b/core/survey/nodeDefExpressionValidator/memberEval.js
@@ -3,11 +3,15 @@ import * as Expression from '@core/expressionParser/expression'
 import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
 
 export const memberEval = (expr, ctx) => {
-  const { object, property } = expr
+  const { object, property, computed } = expr
 
   const objectEval = Expression.evalExpr({ expr: object, ctx })
   if (objectEval === null) {
     return null
+  }
+  if (computed) {
+    // access element at index (e.g. plot[1] or plot[index(...)])
+    return objectEval
   }
   if (Expression.isIdentifier(property)) {
     const propertyName = Expression.getName(property)
@@ -15,9 +19,7 @@ export const memberEval = (expr, ctx) => {
       // simulate node property getter
       return {}
     }
-  } else if (Expression.isLiteral(property)) {
-    // simulate access to element at index, but return only the node def
-    return objectEval
   }
+  // eval property and return it (e.g. plot.plot_id)
   return Expression.evalExpr({ expr: property, ctx: { ...ctx, node: objectEval } })
 }

--- a/core/survey/nodeDefExpressionValidator/memberEval.js
+++ b/core/survey/nodeDefExpressionValidator/memberEval.js
@@ -1,26 +1,8 @@
-import * as Validation from '@core/validation/validation'
-import * as Survey from '@core/survey/survey'
 import * as Expression from '@core/expressionParser/expression'
-import SystemError from '@core/systemError'
 
 import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
 
-const _memberPropertyEval = ({ survey, nodeDefContext, property }) => {
-  const propertyName = Expression.getName(property)
-
-  if (NodeNativeProperties.isNativePropertyAllowed({ nodeDef: nodeDefContext, propertyName })) {
-    // simulate node property getter
-    return {}
-  }
-
-  const childDef = Survey.getNodeDefChildByName(nodeDefContext, propertyName)(survey)
-  if (!childDef) {
-    throw new SystemError(Validation.messageKeys.expressions.unableToFindNode, { name: propertyName })
-  }
-  return childDef
-}
-
-export const memberEval = ({ survey }) => (expr, ctx) => {
+export const memberEval = (expr, ctx) => {
   const { object, property } = expr
 
   const objectEval = Expression.evalExpr({ expr: object, ctx })
@@ -28,9 +10,12 @@ export const memberEval = ({ survey }) => (expr, ctx) => {
     return null
   }
   if (Expression.isIdentifier(property)) {
-    return _memberPropertyEval({ survey, nodeDefContext: objectEval, property })
-  }
-  if (Expression.isLiteral(property)) {
+    const propertyName = Expression.getName(property)
+    if (NodeNativeProperties.isNativePropertyAllowed({ nodeDef: objectEval, propertyName })) {
+      // simulate node property getter
+      return {}
+    }
+  } else if (Expression.isLiteral(property)) {
     // simulate access to element at index, but return only the node def
     return objectEval
   }

--- a/core/survey/nodeDefExpressionValidator/nodeDefExpressionValidator.js
+++ b/core/survey/nodeDefExpressionValidator/nodeDefExpressionValidator.js
@@ -11,13 +11,7 @@ import SystemError from '@core/systemError'
 import { identifierEval } from './identifierEval'
 import { memberEval } from './memberEval'
 
-export const findReferencedNodeDefs = ({
-  survey,
-  nodeDef,
-  exprString,
-  isContextParent = true,
-  selfReferenceAllowed = true,
-}) => {
+const _evaluateExpression = ({ survey, nodeDef, exprString, isContextParent = true, selfReferenceAllowed = true }) => {
   if (!exprString) {
     return []
   }
@@ -45,8 +39,42 @@ export const findReferencedNodeDefs = ({
     },
   }
   const nodeDefContext = isContextParent ? Survey.getNodeDefParent(nodeDef)(survey) : nodeDef
-  Expression.evalString(exprString, { evaluators, functions, node: nodeDefContext })
+  const result = Expression.evalString(exprString, { evaluators, functions, node: nodeDefContext })
+  return { referencedNodeDefs, result }
+}
+
+export const findReferencedNodeDefs = ({
+  survey,
+  nodeDef,
+  exprString,
+  isContextParent = true,
+  selfReferenceAllowed = true,
+}) => {
+  const { referencedNodeDefs } = _evaluateExpression({
+    survey,
+    nodeDef,
+    exprString,
+    isContextParent,
+    selfReferenceAllowed,
+  })
   return referencedNodeDefs
+}
+
+export const findReferencedNodeDefLast = ({
+  survey,
+  nodeDef,
+  exprString,
+  isContextParent = true,
+  selfReferenceAllowed = true,
+}) => {
+  const { result } = _evaluateExpression({
+    survey,
+    nodeDef,
+    exprString,
+    isContextParent,
+    selfReferenceAllowed,
+  })
+  return result
 }
 
 export const validate = ({

--- a/core/survey/nodeDefExpressionValidator/nodeDefExpressionValidator.js
+++ b/core/survey/nodeDefExpressionValidator/nodeDefExpressionValidator.js
@@ -2,6 +2,7 @@ import * as R from 'ramda'
 
 import * as Expression from '@core/expressionParser/expression'
 import * as Survey from '@core/survey/survey'
+import * as NodeDef from '@core/survey/nodeDef'
 import * as Validation from '@core/validation/validation'
 import * as ValidationResult from '@core/validation/validationResult'
 
@@ -10,6 +11,44 @@ import SystemError from '@core/systemError'
 import { identifierEval } from './identifierEval'
 import { memberEval } from './memberEval'
 
+export const findReferencedNodeDefs = ({
+  survey,
+  nodeDef,
+  exprString,
+  isContextParent = true,
+  selfReferenceAllowed = true,
+}) => {
+  if (!exprString) {
+    return []
+  }
+  const referencedNodeDefs = {}
+  const addReferencedNodeDef = (nodeDefRef) => {
+    if (nodeDefRef && !R.isEmpty(nodeDefRef)) {
+      referencedNodeDefs[NodeDef.getUuid(nodeDefRef)] = nodeDefRef
+    }
+    return nodeDefRef
+  }
+  const evaluators = {
+    [Expression.types.Identifier]: (expr, ctx) =>
+      addReferencedNodeDef(
+        identifierEval({ survey, nodeDefCurrent: nodeDef, selfReferenceAllowed, evaluateToNode: true })(expr, ctx)
+      ),
+    [Expression.types.MemberExpression]: (expr, ctx) => addReferencedNodeDef(memberEval(expr, ctx)),
+  }
+  const functions = {
+    [Expression.functionNames.parent]: (nodeDefArg) => {
+      if (NodeDef.isRoot(nodeDefArg)) {
+        return null
+      }
+      const parentDef = Survey.getNodeDefParent(nodeDefArg)(survey)
+      return addReferencedNodeDef(parentDef)
+    },
+  }
+  const nodeDefContext = isContextParent ? Survey.getNodeDefParent(nodeDef)(survey) : nodeDef
+  Expression.evalString(exprString, { evaluators, functions, node: nodeDefContext })
+  return referencedNodeDefs
+}
+
 export const validate = ({
   survey,
   nodeDefCurrent,
@@ -17,13 +56,8 @@ export const validate = ({
   isContextParent = false,
   selfReferenceAllowed = false,
 }) => {
-  const evaluators = {
-    [Expression.types.Identifier]: identifierEval({ survey, nodeDefCurrent, selfReferenceAllowed }),
-    [Expression.types.MemberExpression]: memberEval({ survey }),
-  }
   try {
-    const nodeDefContext = isContextParent ? Survey.getNodeDefParent(nodeDefCurrent)(survey) : nodeDefCurrent
-    Expression.evalString(exprString, { evaluators, node: nodeDefContext })
+    findReferencedNodeDefs({ survey, nodeDef: nodeDefCurrent, exprString, isContextParent, selfReferenceAllowed })
     return null
   } catch (error) {
     const details = R.is(SystemError, error) ? `$t(${error.key})` : error.toString()

--- a/test/unit/tests/002recordExpressionParser.test.js
+++ b/test/unit/tests/002recordExpressionParser.test.js
@@ -21,11 +21,21 @@ describe('RecordExpressionParser Test', () => {
       user,
       SB.entity(
         'cluster',
-        SB.attribute('tree_height', NodeDef.nodeDefType.integer),
-        SB.attribute('dbh', NodeDef.nodeDefType.integer),
+        SB.attribute('cluster_id', NodeDef.nodeDefType.integer).key(),
+        SB.attribute('cluster_distance', NodeDef.nodeDefType.integer).key(),
         SB.attribute('visit_date', NodeDef.nodeDefType.date),
         SB.attribute('remarks', NodeDef.nodeDefType.text),
-        SB.entity('plot', SB.attribute('plot_id').key(), SB.attribute('plot_multiple_number').multiple()).multiple()
+        SB.entity(
+          'plot',
+          SB.attribute('plot_id', NodeDef.nodeDefType.integer).key(),
+          SB.attribute('plot_multiple_number', NodeDef.nodeDefType.integer).multiple(),
+          SB.entity(
+            'tree',
+            SB.attribute('tree_id', NodeDef.nodeDefType.integer).key(),
+            SB.attribute('tree_height', NodeDef.nodeDefType.integer),
+            SB.attribute('dbh', NodeDef.nodeDefType.decimal)
+          ).multiple()
+        ).multiple()
       )
     ).build()
 
@@ -34,75 +44,70 @@ describe('RecordExpressionParser Test', () => {
       survey,
       RB.entity(
         'cluster',
-        RB.attribute('tree_height', 12),
-        RB.attribute('dbh', 18),
+        RB.attribute('cluster_id', 12),
+        RB.attribute('cluster_distance', 18),
         RB.attribute('visit_date', '2021-01-01'),
         RB.attribute('remarks', ''),
         RB.entity(
           'plot',
           RB.attribute('plot_id', 1),
           RB.attribute('plot_multiple_number', 10),
-          RB.attribute('plot_multiple_number', 20)
+          RB.attribute('plot_multiple_number', 20),
+          RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
+          RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 11), RB.attribute('dbh', 10))
         ),
-        RB.entity('plot', RB.attribute('plot_id', 2)),
-        RB.entity('plot', RB.attribute('plot_id', 3), RB.attribute('plot_multiple_number', 30))
+        RB.entity(
+          'plot',
+          RB.attribute('plot_id', 2),
+          RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 12), RB.attribute('dbh', 18)),
+          RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 10), RB.attribute('dbh', 15)),
+          RB.entity('tree', RB.attribute('tree_id', 3), RB.attribute('tree_height', 30), RB.attribute('dbh', 20))
+        ),
+        RB.entity(
+          'plot',
+          RB.attribute('plot_id', 3),
+          RB.attribute('plot_multiple_number', 30),
+          RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 13), RB.attribute('dbh', 19)),
+          RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 10), RB.attribute('dbh', 15)),
+          RB.entity('tree', RB.attribute('tree_id', 3), RB.attribute('tree_height', 11), RB.attribute('dbh', 16)),
+          RB.entity('tree', RB.attribute('tree_id', 4), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
+          RB.entity('tree', RB.attribute('tree_id', 5), RB.attribute('tree_height', 33), RB.attribute('dbh', 22))
+        )
       )
     ).build()
 
-    nodeDefault = RecordUtils.findNodeByPath('cluster/tree_height')(survey, record)
+    nodeDefault = RecordUtils.findNodeByPath('cluster/cluster_id')(survey, record)
   }, 10000)
-
-  // ====== nodes hierarchy tests
-  // it('this.parent()', async () => {
-  //   const res = RecordExpressionParser.evalNodeQuery(survey, record, node, 'this.parent()')
-  //   const p = Record.getParentNode(node)(record)
-  //   assert.equal(Node.getUuid(res), Node.getUuid(root))
-  // })
-
-  // it('this.parent().parent()', async () => {
-  //   const res = RecordExpressionParser.evalNodeQuery(survey, record, node, 'this.parent().parent()')
-  //   assert.equal(res, null)
-  // })
-
-  // it(`dbh`, async () => {
-  //   const res = RecordExpressionParser.evalNodeQuery(survey, record, node, `dbh`)
-  //   assert.equal(Node.getUuid(res), Node.getUuid(dbh))
-  // })
-
-  // it(`dbh`, async () => {
-  //   const res = RecordExpressionParser.evalNodeQuery(survey, record, node, `dbh`)
-  //   assert.equal(Node.getUuid(res), Node.getUuid(dbh))
-  // })
 
   // ====== value expr tests
   const queries = [
-    { q: 'tree_height + 1', r: 13 },
-    { q: 'tree_height != 1', r: true },
+    { q: 'cluster_id + 1', r: 13 },
+    { q: 'cluster_id != 1', r: true },
     // !12 == null under strict logical negation semantics
-    { q: '!tree_height', r: null },
+    { q: '!cluster_id', r: null },
     // Number + String is invalid -> null
-    { q: 'tree_height + "1"', r: null },
-    { q: '!(tree_height == 1)', r: true },
+    { q: 'cluster_id + "1"', r: null },
+    { q: '!(cluster_id == 1)', r: true },
     // 18 + 1
-    { q: 'dbh + 1', r: 19 },
+    { q: 'cluster_distance + 1', r: 19 },
     // 18 + 1
-    { q: 'dbh + 1', r: 19 },
+    { q: 'cluster_distance + 1', r: 19 },
     // 18 + 1 + 12
-    { q: 'dbh + 1 + tree_height', r: 31 },
+    { q: 'cluster_distance + 1 + cluster_id', r: 31 },
     // 18 + 12
-    { q: 'dbh + tree_height', r: 30 },
+    { q: 'cluster_distance + cluster_id', r: 30 },
     // 19 >= 12
-    { q: 'dbh + 1 >= tree_height', r: true },
+    { q: 'cluster_distance + 1 >= cluster_id', r: true },
     // 18 * 0.5 >= 12
-    { q: '(dbh * 0.5) >= tree_height', r: false },
+    { q: '(cluster_distance * 0.5) >= cluster_id', r: false },
     // 1728
-    { q: 'pow(tree_height, 3)', r: 1728 },
+    { q: 'pow(cluster_id, 3)', r: 1728 },
     // 18 * 0.5 >= 1728
-    { q: '(dbh * 0.5) >= pow(tree_height, 3)', r: false },
+    { q: '(cluster_distance * 0.5) >= pow(cluster_id, 3)', r: false },
     // visit_date must be before current date
     { q: 'visit_date <= now()', r: true },
-    // tree_height is not empty
-    { q: 'isEmpty(tree_height)', r: false },
+    // cluster_id is not empty
+    { q: 'isEmpty(cluster_id)', r: false },
     // remarks is empty
     { q: 'isEmpty(remarks)', r: true },
     // plot count is 3
@@ -144,7 +149,14 @@ describe('RecordExpressionParser Test', () => {
     { q: 'parent(plot_id)', r: () => getNode('cluster/plot[1]'), n: 'cluster/plot[1]/plot_id' },
     { q: 'parent(parent(plot_id))', r: () => getNode('cluster'), n: 'cluster/plot[1]/plot_id' },
     { q: 'index(parent(plot_id))', r: 1, n: 'cluster/plot[1]/plot_id' },
-    { q: 'parent(parent(plot_id)).plot[index(parent(plot_id))-1].plot_id', r: 1, n: 'cluster/plot[1]/plot_id' },
+    // access plot_id of previous plot
+    { q: 'parent(parent(plot_id)).plot[index(parent(plot_id)) - 1].plot_id', r: 1, n: 'cluster/plot[1]/plot_id' },
+    // access dbh of a tree inside sibling plot
+    {
+      q: 'parent(parent(parent(dbh))).plot[index(parent(parent(dbh))) - 2].tree[1].dbh',
+      r: 10,
+      n: 'cluster/plot[2]/tree[1]/dbh',
+    },
   ]
 
   queries.forEach(({ q, r, n }) => {

--- a/webapp/components/expression/codemirrorArenaExpressionHint.js
+++ b/webapp/components/expression/codemirrorArenaExpressionHint.js
@@ -11,6 +11,7 @@ const functionExamples = {
     [Expression.functionNames.isEmpty]: `isEmpty(attribute_name) = true/false`,
     [Expression.functionNames.min]: 'min(3,1) = 1',
     [Expression.functionNames.max]: 'max(3,1,2) = 3',
+    [Expression.functionNames.parent]: `parent(node_name)`,
     [Expression.functionNames.pow]: 'pow(2,3) = 2³ = 8',
     [Expression.functionNames.ln]: 'ln(10) = 2.302…',
     [Expression.functionNames.log10]: 'log10(100) = 2',


### PR DESCRIPTION
## Related Issue

Resolves #1402 

## Brief description of the changes proposed an/or how the issue(s) has(have) been solved.

The parent() function takes a node as argument and returns the parent entity of the specified node. 

Most of the changes have been applied to:
- nodeDefExpressionValidator: the same logic used to validate the expression is used to find the node definition referenced by the expression itself;
- surveyDependencies: now it uses the nodeDefExpressionValidator to get the node definition referenced by the expression (when the parent function is used, even the parent node definition must be considered).
- RecordExpressionParser internal modules: memberEval.js and identifierEval.js has been simplified a bit.
- SurveyDependencyTypes: it has been introduced to avoid import cycles;
- codemirrorArenaExpressionHint.js: it has been modified to support the use of the parent function in the expressions and to autocomplete the variables accordingly;

## How has this been tested

The function has been tested with unit tests, using attributes, entities and results of other function calls as arguments.
The unit tests in 002recordExpressionParser.test.js has been improved by adding another level (tree) to the structure of the test survey.

##### Do you consider this PR needs further testing?
- [x] No
- [ ] Yes

## Types of changes

- [ ] Docs change 
- [ ] Refactoring 
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Disclaimer

In surveyDependencies, exceptions during evaluation of expressions are ignored. Can an expression stored in the system be invalid for some reason? For example if the way expression is parsed changes? What should we do in that case?

In the advanced expression editor, variables are not shown correctly with complex expressions (e.g. inside parenthesis or when autocompleting variables to be used as arguments of function calls).