### PR TITLE
Feature/expressions native identifiers

### DIFF
--- a/core/expressionParser/expression.js
+++ b/core/expressionParser/expression.js
@@ -82,3 +82,5 @@ export const newBinary = (left, right, operator = '') => ({
   left,
   right,
 })
+
+export const globalIdentifierEval = Evaluator.globalIdentifierEval

--- a/core/expressionParser/helpers/evaluator.js
+++ b/core/expressionParser/helpers/evaluator.js
@@ -119,14 +119,23 @@ const callEval = (expr, ctx) => {
   const { callee, arguments: exprArgs } = expr
   const { functions: functionsCtx = {} } = ctx
 
-  const fnName = callee.name
-  const numArgs = exprArgs.length
+  if (callee.type === types.MemberExpression) {
+    // global function (e.g. Math.round(...))
+    const fn = evalExpression(callee, ctx)
+    if (fn) {
+      const args = exprArgs.map((arg) => evalExpression(arg, ctx))
+      return R.apply(fn, args)
+    }
+  }
 
   // No complex expressions may be put in place of a function body.
   // Only a plain identifier is allowed.
   if (callee.type !== types.Identifier) {
     throw new SystemError('invalidSyntax', { fnType: callee.type })
   }
+
+  const fnName = callee.name
+  const numArgs = exprArgs.length
 
   // The function must be found in the standard library.
   const functionInfo = functions[fnName]
@@ -193,6 +202,13 @@ const evaluatorsDefault = {
   [types.GroupExpression]: groupEval,
 }
 
+const globalObjects = {
+  Date,
+  Math,
+  Number,
+  String,
+}
+
 export const evalExpression = (expr, ctx = {}) => {
   const evaluators = R.pipe(R.prop('evaluators'), R.mergeRight(evaluatorsDefault))(ctx)
 
@@ -202,4 +218,18 @@ export const evalExpression = (expr, ctx = {}) => {
   }
 
   return fn(expr, ctx)
+}
+
+export const globalIdentifierEval = ({ identifierName, exprContext }) => {
+  if (identifierName in globalObjects) {
+    return globalObjects[identifierName]
+  }
+  if (Object.values(globalObjects).includes(exprContext)) {
+    const result = exprContext[identifierName]
+    if (!result) {
+      throw new SystemError('undefinedFunction', { fnName: identifierName })
+    }
+    return result
+  }
+  return null
 }

--- a/core/expressionParser/helpers/evaluator.js
+++ b/core/expressionParser/helpers/evaluator.js
@@ -203,6 +203,7 @@ const evaluatorsDefault = {
 }
 
 const globalObjects = {
+  Array,
   Date,
   Math,
   Number,

--- a/core/record/recordExpressionParser/identifierEval.js
+++ b/core/record/recordExpressionParser/identifierEval.js
@@ -110,10 +110,17 @@ const _getReferencedNodes = ({ survey, record, node, nodeDefReferenced }) => {
   return []
 }
 
-export const identifierEval = (survey, record) => (expr, { node, evaluateToNode }) => {
-  const nodeNameReferenced = Expression.getName(expr)
+export const identifierEval = (survey, record) => (expr, { node: exprContext, evaluateToNode }) => {
+  const exprName = Expression.getName(expr)
+
+  const globalIdentifierEvalResult = Expression.globalIdentifierEval({ identifierName: exprName, exprContext })
+  if (globalIdentifierEvalResult !== null) {
+    return globalIdentifierEvalResult
+  }
+
+  const node = exprContext
   const nodeDefCtx = Survey.getNodeDefByUuid(Node.getNodeDefUuid(node))(survey)
-  const nodeDefReferenced = Survey.getNodeDefByName(nodeNameReferenced)(survey)
+  const nodeDefReferenced = Survey.getNodeDefByName(exprName)(survey)
 
   let nodeResult = null
   if (NodeDef.isEqual(nodeDefCtx)(nodeDefReferenced)) {
@@ -133,7 +140,7 @@ export const identifierEval = (survey, record) => (expr, { node, evaluateToNode 
 
   const single = NodeDef.isSingle(nodeDefReferenced)
   if (single && (referencedNodes.length === 0 || referencedNodes.length > 1)) {
-    throw new SystemError(Validation.messageKeys.expressions.unableToFindNode, { name: nodeNameReferenced })
+    throw new SystemError(Validation.messageKeys.expressions.unableToFindNode, { name: exprName })
   }
 
   if (NodeDef.isAttribute(nodeDefReferenced) && !evaluateToNode) {


### PR DESCRIPTION
## Related Issue

Resolves (partially) #1398

## Brief description of the changes proposed an/or how the issue(s) has(have) been solved.

This pull request allows the use of the global objects Array, Math, Number, String in the advanced expression editor.

## How has this been tested

Unit tests have been added to test the use of Array, Math, Number, String, even with the use of arguments resulting from the evaluation of record nodes.

##### Do you consider this PR needs further testing?
- [x] No
- [ ] Yes

## Types of changes

- [ ] Docs change 
- [ ] Refactoring 
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Disclaimer

The autocompletion does not show the global objects and their properties.
This feature will be added in the next pull request.