### PR TITLE
Expressions: allowed use of native object properties

### DIFF
--- a/core/i18n/resources/en.js
+++ b/core/i18n/resources/en.js
@@ -703,7 +703,6 @@ $t(common.cantUndoWarning)`,
 
     expressions: {
       cannotGetChildOfAttribute: 'cannot get child node {{childName}} of attribute {{parentName}}',
-      cannotGetLengthOfSingleNodes: 'cannot get the length of a single node',
       cannotUseCurrentNode: 'cannot use current node {{name}} in this expression',
       circularDependencyError: 'cannot reference node {{name}} because it references the current node',
       expressionInvalid: 'Invalid expression: {{details}}',

--- a/core/record/recordExpressionParser/identifierEval.js
+++ b/core/record/recordExpressionParser/identifierEval.js
@@ -113,11 +113,19 @@ const _getReferencedNodes = ({ survey, record, node, nodeDefReferenced }) => {
 export const identifierEval = (survey, record) => (expr, { node: exprContext, evaluateToNode }) => {
   const exprName = Expression.getName(expr)
 
+  // identifier is global object
   const globalIdentifierEvalResult = Expression.globalIdentifierEval({ identifierName: exprName, exprContext })
   if (globalIdentifierEvalResult !== null) {
     return globalIdentifierEvalResult
   }
 
+  // identifier is a native property or function (e.g. String.length or String.toUpperCase())
+  const prop = exprContext[exprName]
+  if (prop !== undefined) {
+    return prop instanceof Function ? prop.bind(exprContext) : prop
+  }
+
+  // identifier references a node
   const node = exprContext
   const nodeDefCtx = Survey.getNodeDefByUuid(Node.getNodeDefUuid(node))(survey)
   const nodeDefReferenced = Survey.getNodeDefByName(exprName)(survey)

--- a/core/record/recordExpressionParser/memberEval.js
+++ b/core/record/recordExpressionParser/memberEval.js
@@ -1,20 +1,11 @@
 import * as Expression from '@core/expressionParser/expression'
 
-import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
-
 export const memberEval = (expr, ctx) => {
   const { object, property, computed } = expr
 
   const objectEval = Expression.evalExpr({ expr: object, ctx })
   if (!objectEval) {
     return null
-  }
-  if (!computed && Expression.isIdentifier(property)) {
-    const propertyName = Expression.getName(property)
-    if (NodeNativeProperties.isNativeProperty(propertyName)) {
-      // property is a native property of the node
-      return NodeNativeProperties.evalProperty({ node: objectEval, propertyName })
-    }
   }
 
   if (computed) {

--- a/core/survey/nodeDefExpressionNativeProperties.js
+++ b/core/survey/nodeDefExpressionNativeProperties.js
@@ -12,20 +12,26 @@ const jsTypeByNodeDefType = {
   [NodeDef.nodeDefType.text]: String,
 }
 
-export const hasNativeProperty = ({ nodeDef, propertyName }) => {
-  if (propertyName === nativeProperties.length && NodeDef.isMultiple(nodeDef)) {
+const _hasProperty = ({ jsType, propName }) => Object.prototype.hasOwnProperty.call(jsType, propName)
+const _hasFunction = ({ jsType, funcName }) => Boolean(jsType.prototype[funcName])
+
+export const hasNativeProperty = ({ nodeDef, propName }) => {
+  if (propName === nativeProperties.length && NodeDef.isMultiple(nodeDef)) {
     return true
   }
   const jsType = jsTypeByNodeDefType[NodeDef.getType(nodeDef)]
-  return jsType && (Object.prototype.hasOwnProperty.call(jsType, propertyName) || jsType.prototype[propertyName])
+  return jsType && (_hasProperty({ jsType, propName }) || _hasFunction({ jsType, funcName: propName }))
 }
 
-export const evalNodeDefProperty = ({ nodeDef, propertyName }) => {
-  if (propertyName === nativeProperties.length) {
+export const evalNodeDefProperty = ({ nodeDef, propName }) => {
+  if (propName === nativeProperties.length) {
     return 0
   }
   const jsType = jsTypeByNodeDefType[NodeDef.getType(nodeDef)]
-  return Object.prototype.hasOwnProperty.call(jsType, propertyName)
-    ? jsType[propertyName]
-    : jsType.prototype[propertyName].bind({})
+  if (_hasProperty({ jsType, propName })) {
+    return jsType[propName]
+  } else {
+    // return function with name "propertyName" and bind it to an empty object
+    return jsType.prototype[propName].bind({})
+  }
 }

--- a/core/survey/nodeDefExpressionValidator/identifierEval.js
+++ b/core/survey/nodeDefExpressionValidator/identifierEval.js
@@ -50,8 +50,8 @@ export const identifierEval = ({ survey, nodeDefCurrent }) => (expr, ctx) => {
   }
 
   // identifier is a native property or function (e.g. String.length or String.toUpperCase())
-  if (NodeNativeProperties.hasNativeProperty({ nodeDef: exprContext, propName: exprName })) {
-    return NodeNativeProperties.evalNodeDefProperty({ nodeDef: exprContext, propName: exprName })
+  if (NodeNativeProperties.hasNativeProperty({ nodeDefOrValue: exprContext, propName: exprName })) {
+    return NodeNativeProperties.evalNodeDefProperty({ nodeDefOrValue: exprContext, propName: exprName })
   }
 
   // identifier references a node

--- a/core/survey/nodeDefExpressionValidator/identifierEval.js
+++ b/core/survey/nodeDefExpressionValidator/identifierEval.js
@@ -1,6 +1,7 @@
 import * as Validation from '@core/validation/validation'
 import * as Survey from '@core/survey/survey'
 import * as NodeDef from '@core/survey/nodeDef'
+import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
 import * as Expression from '@core/expressionParser/expression'
 import Queue from '@core/queue'
 import SystemError from '@core/systemError'
@@ -53,6 +54,12 @@ export const identifierEval = ({ survey, nodeDefCurrent, selfReferenceAllowed, e
     return globalIdentifierEvalResult
   }
 
+  // identifier is a native property or function (e.g. String.length or String.toUpperCase())
+  if (NodeNativeProperties.hasNativeProperty({ nodeDef: exprContext, propName: exprName })) {
+    return NodeNativeProperties.evalNodeDefProperty({ nodeDef: exprContext, propName: exprName })
+  }
+
+  // identifier references a node
   const reachableNodeDefs = _getReachableNodeDefs(survey, exprContext)
 
   const def = reachableNodeDefs.find((x) => NodeDef.getName(x) === exprName)

--- a/core/survey/nodeDefExpressionValidator/identifierEval.js
+++ b/core/survey/nodeDefExpressionValidator/identifierEval.js
@@ -6,8 +6,6 @@ import * as Expression from '@core/expressionParser/expression'
 import Queue from '@core/queue'
 import SystemError from '@core/systemError'
 
-const _getNodeValue = (nodeDef) => (NodeDef.isCode(nodeDef) || NodeDef.isTaxon(nodeDef) ? { props: { code: '' } } : 1) // Simulates node value
-
 // Get reachable nodes, i.e. the children of the node's ancestors.
 // NOTE: The root node is excluded, but it _should_ be an entity, so that is fine.
 const _getReachableNodeDefs = (survey, nodeDefContext) => {
@@ -41,11 +39,8 @@ const _getReachableNodeDefs = (survey, nodeDefContext) => {
   return reachableNodeDefs
 }
 
-export const identifierEval = ({ survey, nodeDefCurrent, selfReferenceAllowed, evaluateToNode = false }) => (
-  expr,
-  ctx
-) => {
-  const { node: exprContext } = ctx
+export const identifierEval = ({ survey, nodeDefCurrent }) => (expr, ctx) => {
+  const { node: exprContext, selfReferenceAllowed = true } = ctx
 
   const exprName = Expression.getName(expr)
 
@@ -83,5 +78,5 @@ export const identifierEval = ({ survey, nodeDefCurrent, selfReferenceAllowed, e
     throw new SystemError(Validation.messageKeys.expressions.circularDependencyError, { name: exprName })
   }
 
-  return NodeDef.isEntity(def) || NodeDef.isMultiple(def) || evaluateToNode ? def : _getNodeValue(def)
+  return def
 }

--- a/core/survey/nodeDefExpressionValidator/memberEval.js
+++ b/core/survey/nodeDefExpressionValidator/memberEval.js
@@ -1,7 +1,5 @@
 import * as Expression from '@core/expressionParser/expression'
 
-import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
-
 export const memberEval = (expr, ctx) => {
   const { object, property, computed } = expr
 
@@ -12,12 +10,6 @@ export const memberEval = (expr, ctx) => {
   if (computed) {
     // access element at index (e.g. plot[1] or plot[index(...)])
     return objectEval
-  }
-  if (Expression.isIdentifier(property)) {
-    const propName = Expression.getName(property)
-    if (NodeNativeProperties.hasNativeProperty({ nodeDef: objectEval, propName })) {
-      return NodeNativeProperties.evalNodeDefProperty({ nodeDef: objectEval, propName })
-    }
   }
   // eval property and return it (e.g. plot.plot_id)
   return Expression.evalExpr({ expr: property, ctx: { ...ctx, node: objectEval } })

--- a/core/survey/nodeDefExpressionValidator/memberEval.js
+++ b/core/survey/nodeDefExpressionValidator/memberEval.js
@@ -15,9 +15,8 @@ export const memberEval = (expr, ctx) => {
   }
   if (Expression.isIdentifier(property)) {
     const propertyName = Expression.getName(property)
-    if (NodeNativeProperties.isNativePropertyAllowed({ nodeDef: objectEval, propertyName })) {
-      // simulate node property getter
-      return {}
+    if (NodeNativeProperties.hasNativeProperty({ nodeDef: objectEval, propertyName })) {
+      return NodeNativeProperties.evalNodeDefProperty({ nodeDef: objectEval, propertyName })
     }
   }
   // eval property and return it (e.g. plot.plot_id)

--- a/core/survey/nodeDefExpressionValidator/memberEval.js
+++ b/core/survey/nodeDefExpressionValidator/memberEval.js
@@ -14,9 +14,9 @@ export const memberEval = (expr, ctx) => {
     return objectEval
   }
   if (Expression.isIdentifier(property)) {
-    const propertyName = Expression.getName(property)
-    if (NodeNativeProperties.hasNativeProperty({ nodeDef: objectEval, propertyName })) {
-      return NodeNativeProperties.evalNodeDefProperty({ nodeDef: objectEval, propertyName })
+    const propName = Expression.getName(property)
+    if (NodeNativeProperties.hasNativeProperty({ nodeDef: objectEval, propName })) {
+      return NodeNativeProperties.evalNodeDefProperty({ nodeDef: objectEval, propName })
     }
   }
   // eval property and return it (e.g. plot.plot_id)

--- a/core/survey/nodeDefExpressionValidator/memberEval.js
+++ b/core/survey/nodeDefExpressionValidator/memberEval.js
@@ -12,5 +12,7 @@ export const memberEval = (expr, ctx) => {
     return objectEval
   }
   // eval property and return it (e.g. plot.plot_id)
-  return Expression.evalExpr({ expr: property, ctx: { ...ctx, node: objectEval } })
+  // allow self node def reference because the referenced node at runtime can be different from current node
+  // e.g. current node = plot_id ; expression = parent(plot).plot[index(plot) - 1].plot_id
+  return Expression.evalExpr({ expr: property, ctx: { ...ctx, node: objectEval, selfReferenceAllowed: true } })
 }

--- a/core/survey/nodeDefExpressionValidator/nodeDefExpressionValidator.js
+++ b/core/survey/nodeDefExpressionValidator/nodeDefExpressionValidator.js
@@ -24,9 +24,7 @@ const _evaluateExpression = ({ survey, nodeDef, exprString, isContextParent = tr
   }
   const evaluators = {
     [Expression.types.Identifier]: (expr, ctx) =>
-      addReferencedNodeDef(
-        identifierEval({ survey, nodeDefCurrent: nodeDef, selfReferenceAllowed, evaluateToNode: true })(expr, ctx)
-      ),
+      addReferencedNodeDef(identifierEval({ survey, nodeDefCurrent: nodeDef })(expr, ctx)),
     [Expression.types.MemberExpression]: (expr, ctx) => addReferencedNodeDef(memberEval(expr, ctx)),
   }
   const functions = {
@@ -39,7 +37,12 @@ const _evaluateExpression = ({ survey, nodeDef, exprString, isContextParent = tr
     },
   }
   const nodeDefContext = isContextParent ? Survey.getNodeDefParent(nodeDef)(survey) : nodeDef
-  const result = Expression.evalString(exprString, { evaluators, functions, node: nodeDefContext })
+  const result = Expression.evalString(exprString, {
+    evaluators,
+    functions,
+    node: nodeDefContext,
+    selfReferenceAllowed,
+  })
   return { referencedNodeDefs, result }
 }
 

--- a/core/validation/_validator/validatorErrorKeys.js
+++ b/core/validation/_validator/validatorErrorKeys.js
@@ -50,7 +50,6 @@ export const ValidatorErrorKeys = {
 
   expressions: {
     cannotGetChildOfAttribute: 'validationErrors.expressions.cannotGetChildOfAttribute',
-    cannotGetLengthOfSingleNodes: 'validationErrors.expressions.cannotGetLengthOfSingleNodes',
     cannotUseCurrentNode: 'validationErrors.expressions.cannotUseCurrentNode',
     circularDependencyError: 'validationErrors.expressions.circularDependencyError',
     expressionInvalid: 'validationErrors.expressions.expressionInvalid',

--- a/test/unit/tests/002recordExpressionParser.test.js
+++ b/test/unit/tests/002recordExpressionParser.test.js
@@ -125,6 +125,8 @@ describe('RecordExpressionParser Test', () => {
     // native properties (string)
     { q: 'gps_model.toLowerCase()', r: 'abc-123-xyz' },
     { q: 'gps_model.substring(4,7)', r: '123' },
+    { q: 'gps_model.length', r: 11 },
+    { q: 'gps_model[1]', r: 'B' },
   ]
 
   NodeDefExpressionUtils.testRecordExpressions({ surveyFn: () => survey, recordFn: () => record, queries })

--- a/test/unit/tests/002recordExpressionParser.test.js
+++ b/test/unit/tests/002recordExpressionParser.test.js
@@ -1,18 +1,14 @@
-import * as NodeDef from '@core/survey/nodeDef'
-
-import * as RecordExpressionParser from '@core/record/recordExpressionParser'
 import * as Validation from '@core/validation/validation'
 import SystemError from '@core/systemError'
 
 import * as RecordUtils from '../../utils/recordUtils'
-import * as SB from '../../utils/surveyBuilder'
-import * as RB from '../../utils/recordBuilder'
+import * as DataTest from '../../utils/dataTest'
+import * as NodeDefExpressionUtils from '../../utils/nodeDefExpressionUtils'
+
 import { getContextUser } from '../../integration/config/context'
 
 let survey = {}
 let record = {}
-
-let nodeDefault = {}
 
 const getNode = (path) => RecordUtils.findNodeByPath(path)(survey, record)
 
@@ -20,68 +16,9 @@ describe('RecordExpressionParser Test', () => {
   beforeAll(async () => {
     const user = getContextUser()
 
-    survey = SB.survey(
-      user,
-      SB.entity(
-        'cluster',
-        SB.attribute('cluster_id', NodeDef.nodeDefType.integer).key(),
-        SB.attribute('cluster_distance', NodeDef.nodeDefType.integer).key(),
-        SB.attribute('visit_date', NodeDef.nodeDefType.date),
-        SB.attribute('gps_model', NodeDef.nodeDefType.text),
-        SB.attribute('remarks', NodeDef.nodeDefType.text),
-        SB.entity(
-          'plot',
-          SB.attribute('plot_id', NodeDef.nodeDefType.integer).key(),
-          SB.attribute('plot_multiple_number', NodeDef.nodeDefType.integer).multiple(),
-          SB.entity(
-            'tree',
-            SB.attribute('tree_id', NodeDef.nodeDefType.integer).key(),
-            SB.attribute('tree_height', NodeDef.nodeDefType.integer),
-            SB.attribute('dbh', NodeDef.nodeDefType.decimal)
-          ).multiple()
-        ).multiple()
-      )
-    ).build()
+    survey = DataTest.createTestSurvey({ user })
 
-    record = RB.record(
-      user,
-      survey,
-      RB.entity(
-        'cluster',
-        RB.attribute('cluster_id', 12),
-        RB.attribute('cluster_distance', 18),
-        RB.attribute('visit_date', '2021-01-01'),
-        RB.attribute('gps_model', 'ABC-123-xyz'),
-        RB.attribute('remarks', ''),
-        RB.entity(
-          'plot',
-          RB.attribute('plot_id', 1),
-          RB.attribute('plot_multiple_number', 10),
-          RB.attribute('plot_multiple_number', 20),
-          RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
-          RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 11), RB.attribute('dbh', 10.123))
-        ),
-        RB.entity(
-          'plot',
-          RB.attribute('plot_id', 2),
-          RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 12), RB.attribute('dbh', 18)),
-          RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 10), RB.attribute('dbh', 15)),
-          RB.entity('tree', RB.attribute('tree_id', 3), RB.attribute('tree_height', 30), RB.attribute('dbh', 20))
-        ),
-        RB.entity(
-          'plot',
-          RB.attribute('plot_id', 3),
-          RB.attribute('plot_multiple_number', 30),
-          RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 13), RB.attribute('dbh', 19)),
-          RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 10), RB.attribute('dbh', 15)),
-          RB.entity('tree', RB.attribute('tree_id', 3), RB.attribute('tree_height', 11), RB.attribute('dbh', 16)),
-          RB.entity('tree', RB.attribute('tree_id', 4), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
-          RB.entity('tree', RB.attribute('tree_id', 5), RB.attribute('tree_height', 33), RB.attribute('dbh', 22))
-        )
-      )
-    ).build()
-
-    nodeDefault = RecordUtils.findNodeByPath('cluster/cluster_id')(survey, record)
+    record = DataTest.createTestRecord({ user, survey })
   }, 10000)
 
   // ====== value expr tests
@@ -190,26 +127,5 @@ describe('RecordExpressionParser Test', () => {
     { q: 'gps_model.substring(4,7)', r: '123' },
   ]
 
-  queries.forEach(({ q, r, n, e }) => {
-    const testTitle = `${q}${n ? ` (${n})` : ''}`
-    it(testTitle, () => {
-      try {
-        const resKeys = r && typeof r == 'object' ? Object.keys(r) : []
-        const node = n ? getNode(n) : nodeDefault
-        const res = RecordExpressionParser.evalNodeQuery(survey, record, node, q)
-        if (resKeys.length === 0) {
-          const resExpected = r instanceof Function ? r() : r
-          expect(res).toEqual(resExpected)
-        } else {
-          resKeys.forEach((key) => expect(res[key]).toEqual(r[key]))
-        }
-      } catch (error) {
-        if (e) {
-          expect(error).toEqual(e)
-        } else {
-          throw error
-        }
-      }
-    })
-  })
+  NodeDefExpressionUtils.testRecordExpressions({ surveyFn: () => survey, recordFn: () => record, queries })
 })

--- a/test/unit/tests/007nodeDefExpressionValidator.test.js
+++ b/test/unit/tests/007nodeDefExpressionValidator.test.js
@@ -40,7 +40,6 @@ describe('NodeDefExpressionValidator Test', () => {
     { q: 'index(plot, plot_id)', n: 'plot', r: false },
     // access attribute of sibling entity
     { q: 'plot[index(plot) - 1].plot_id', n: 'plot_id', r: true },
-    { q: 'plot[index(plot) - 1].plot_id', n: 'plot_id', r: true },
     // parent function
     { q: 'parent(plot_id)', n: 'plot_id', r: true },
     // global objects

--- a/test/unit/tests/007nodeDefExpressionValidator.test.js
+++ b/test/unit/tests/007nodeDefExpressionValidator.test.js
@@ -1,0 +1,56 @@
+import * as DataTest from '../../utils/dataTest'
+import * as NodeDefExpressionUtils from '../../utils/nodeDefExpressionUtils'
+
+import { getContextUser } from '../../integration/config/context'
+
+let survey = {}
+
+describe('NodeDefExpressionValidator Test', () => {
+  beforeAll(async () => {
+    const user = getContextUser()
+
+    survey = DataTest.createTestSurvey({ user })
+  }, 10000)
+
+  // ====== node def expr tests
+  const queries = [
+    // use of single attribute in context
+    { q: 'cluster_id + 1', r: true },
+    // use of undefined attribute
+    { q: 'cluster_idd + 1', r: false },
+    // use of different attributes
+    { q: 'cluster_distance + cluster_id', r: true },
+    // access of non-rechable nodes (descendant nodes)
+    { q: 'plot_id + 10', r: false },
+    { q: 'dbh + 10', n: 'plot_id', r: false },
+    // now function
+    { q: 'visit_date <= now()', r: true },
+    // now function (with wrong parameters)
+    { q: 'visit_date <= now(123)', r: false },
+    // isEmpty function
+    { q: 'isEmpty(cluster_id)', r: true },
+    // length property (multiple entities)
+    { q: 'plot.length', r: true },
+    // length property (multiple attributes)
+    { q: 'plot_multiple_number.length', n: 'plot_id', r: true },
+    // access multiple entities with index
+    { q: 'plot[0].plot_id', r: true },
+    // index function
+    { q: 'index(plot)', n: 'plot', r: true },
+    { q: 'index(plot, plot_id)', n: 'plot', r: false },
+    // access attribute of sibling entity
+    { q: 'plot[index(plot) - 1].plot_id', n: 'plot_id', r: true },
+    { q: 'plot[index(plot) - 1].plot_id', n: 'plot_id', r: true },
+    // parent function
+    { q: 'parent(plot_id)', n: 'plot_id', r: true },
+    // global objects
+    { q: 'Math.min(plot[0].plot_id, plot[1].plot_id, plot[2].plot_id)', r: true },
+    { q: 'Number.isFinite(plot[1].plot_id)', r: true },
+    { q: 'Number.isSomething(plot[1].plot_id)', r: false },
+    { q: 'String.fromCharCode(65, 66, 67)', r: true },
+    // native properties
+    { q: 'gps_model.toLowerCase()', r: true },
+  ]
+
+  NodeDefExpressionUtils.testNodeDefExpressions({ surveyFn: () => survey, queries })
+})

--- a/test/unit/tests/007nodeDefExpressionValidator.test.js
+++ b/test/unit/tests/007nodeDefExpressionValidator.test.js
@@ -57,8 +57,15 @@ describe('NodeDefExpressionValidator Test', () => {
     { q: 'Number.isFinite(plot[1].plot_id)', r: true },
     { q: 'Number.isSomething(plot[1].plot_id)', r: false },
     { q: 'String.fromCharCode(65, 66, 67)', r: true },
-    // native properties
+    // native properties (number)
+    { q: 'Math.PI.toFixed(2)', r: true },
+    { q: 'plot[0].tree[1].dbh.toFixed(1)', r: true },
+    { q: 'plot[0].tree[1].dbh.toPrecision(4)', r: true },
+    // native properties (string)
     { q: 'gps_model.toLowerCase()', r: true },
+    { q: 'gps_model.substring(4,7)', r: true },
+    { q: 'gps_model.length', r: true },
+    { q: 'gps_model[1]', r: true },
   ]
 
   NodeDefExpressionUtils.testNodeDefExpressions({ surveyFn: () => survey, queries })

--- a/test/unit/tests/007nodeDefExpressionValidator.test.js
+++ b/test/unit/tests/007nodeDefExpressionValidator.test.js
@@ -12,10 +12,20 @@ describe('NodeDefExpressionValidator Test', () => {
     survey = DataTest.createTestSurvey({ user })
   }, 10000)
 
-  // ====== node def expr tests
+  // ======
+  /**
+   * Node def expr tests
+   * query type:
+   * - q: expression to test
+   * - r: expected result (true = valid, false = not valid)
+   * - n: node def name (default to cluster_id)
+   * - s: self reference allowed (default to true).
+   */
   const queries = [
     // use of single attribute in context
     { q: 'cluster_id + 1', r: true },
+    // referencing same attribute when not allowed (error expected)
+    { q: 'cluster_id + 1', r: false, s: false },
     // use of undefined attribute
     { q: 'cluster_idd + 1', r: false },
     // use of different attributes
@@ -38,8 +48,8 @@ describe('NodeDefExpressionValidator Test', () => {
     // index function
     { q: 'index(plot)', n: 'plot', r: true },
     { q: 'index(plot, plot_id)', n: 'plot', r: false },
-    // access attribute of sibling entity
-    { q: 'plot[index(plot) - 1].plot_id', n: 'plot_id', r: true },
+    // access same attribute attribute in sibling entity (even when self reference is not allowed)
+    { q: 'plot[index(plot) - 1].plot_id + 1', n: 'plot_id', r: true, s: false },
     // parent function
     { q: 'parent(plot_id)', n: 'plot_id', r: true },
     // global objects

--- a/test/utils/dataTest/dataTest.js
+++ b/test/utils/dataTest/dataTest.js
@@ -1,0 +1,67 @@
+import * as NodeDef from '@core/survey/nodeDef'
+
+import * as SB from '../surveyBuilder'
+import * as RB from '../recordBuilder'
+
+export const createTestSurvey = ({ user }) =>
+  SB.survey(
+    user,
+    SB.entity(
+      'cluster',
+      SB.attribute('cluster_id', NodeDef.nodeDefType.integer).key(),
+      SB.attribute('cluster_distance', NodeDef.nodeDefType.integer),
+      SB.attribute('visit_date', NodeDef.nodeDefType.date),
+      SB.attribute('gps_model', NodeDef.nodeDefType.text),
+      SB.attribute('remarks', NodeDef.nodeDefType.text),
+      SB.entity(
+        'plot',
+        SB.attribute('plot_id', NodeDef.nodeDefType.integer).key(),
+        SB.attribute('plot_multiple_number', NodeDef.nodeDefType.integer).multiple(),
+        SB.entity(
+          'tree',
+          SB.attribute('tree_id', NodeDef.nodeDefType.integer).key(),
+          SB.attribute('tree_height', NodeDef.nodeDefType.integer),
+          SB.attribute('dbh', NodeDef.nodeDefType.decimal)
+        ).multiple()
+      ).multiple()
+    )
+  ).build()
+
+export const createTestRecord = ({ user, survey }) =>
+  RB.record(
+    user,
+    survey,
+    RB.entity(
+      'cluster',
+      RB.attribute('cluster_id', 12),
+      RB.attribute('cluster_distance', 18),
+      RB.attribute('visit_date', '2021-01-01'),
+      RB.attribute('gps_model', 'ABC-123-xyz'),
+      RB.attribute('remarks', ''),
+      RB.entity(
+        'plot',
+        RB.attribute('plot_id', 1),
+        RB.attribute('plot_multiple_number', 10),
+        RB.attribute('plot_multiple_number', 20),
+        RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
+        RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 11), RB.attribute('dbh', 10.123))
+      ),
+      RB.entity(
+        'plot',
+        RB.attribute('plot_id', 2),
+        RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 12), RB.attribute('dbh', 18)),
+        RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 10), RB.attribute('dbh', 15)),
+        RB.entity('tree', RB.attribute('tree_id', 3), RB.attribute('tree_height', 30), RB.attribute('dbh', 20))
+      ),
+      RB.entity(
+        'plot',
+        RB.attribute('plot_id', 3),
+        RB.attribute('plot_multiple_number', 30),
+        RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 13), RB.attribute('dbh', 19)),
+        RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 10), RB.attribute('dbh', 15)),
+        RB.entity('tree', RB.attribute('tree_id', 3), RB.attribute('tree_height', 11), RB.attribute('dbh', 16)),
+        RB.entity('tree', RB.attribute('tree_id', 4), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
+        RB.entity('tree', RB.attribute('tree_id', 5), RB.attribute('tree_height', 33), RB.attribute('dbh', 22))
+      )
+    )
+  ).build()

--- a/test/utils/dataTest/index.js
+++ b/test/utils/dataTest/index.js
@@ -1,0 +1,1 @@
+export { createTestSurvey, createTestRecord } from './dataTest'

--- a/test/utils/nodeDefExpressionUtils.js
+++ b/test/utils/nodeDefExpressionUtils.js
@@ -1,0 +1,45 @@
+import * as RecordExpressionParser from '@core/record/recordExpressionParser'
+
+import * as RecordUtils from './recordUtils'
+
+const _expectResult = ({ result, resultExpected }) => {
+  const resKeys = resultExpected && typeof resultExpected === 'object' ? Object.keys(resultExpected) : []
+  if (resKeys.length === 0) {
+    const resExpected = resultExpected instanceof Function ? resultExpected() : resultExpected
+    expect(result).toEqual(resExpected)
+  } else {
+    resKeys.forEach((key) => expect(result[key]).toEqual(resultExpected[key]))
+  }
+}
+
+const _testExpressions = ({ queries, expressionEvaluator }) => {
+  queries.forEach(({ q, r, n, e }) => {
+    const testTitle = `${q}${n ? ` (${n})` : ''}`
+
+    it(testTitle, () => {
+      try {
+        const result = expressionEvaluator({ nodePath: n, query: q })
+        _expectResult({ result, resultExpected: r })
+      } catch (error) {
+        if (e) {
+          expect(error).toEqual(e)
+        } else {
+          throw error
+        }
+      }
+    })
+  })
+}
+
+export const testRecordExpressions = ({ surveyFn, recordFn, queries }) => {
+  _testExpressions({
+    queries,
+    expressionEvaluator: ({ nodePath, query }) => {
+      const survey = surveyFn()
+      const record = recordFn()
+      const node = RecordUtils.findNodeByPath(nodePath || 'cluster/cluster_id')(survey, record)
+      expect(node).toBeDefined()
+      return RecordExpressionParser.evalNodeQuery(survey, record, node, query)
+    },
+  })
+}

--- a/test/utils/nodeDefExpressionUtils.js
+++ b/test/utils/nodeDefExpressionUtils.js
@@ -1,4 +1,6 @@
 import * as RecordExpressionParser from '@core/record/recordExpressionParser'
+import * as Survey from '@core/survey/survey'
+import * as NodeDefExpressionValidator from '@core/survey/nodeDefExpressionValidator'
 
 import * as RecordUtils from './recordUtils'
 
@@ -12,7 +14,7 @@ const _expectResult = ({ result, resultExpected }) => {
   }
 }
 
-const _testExpressions = ({ queries, expressionEvaluator }) => {
+const _testExpressions = ({ queries, expressionEvaluator }) =>
   queries.forEach(({ q, r, n, e }) => {
     const testTitle = `${q}${n ? ` (${n})` : ''}`
 
@@ -29,9 +31,8 @@ const _testExpressions = ({ queries, expressionEvaluator }) => {
       }
     })
   })
-}
 
-export const testRecordExpressions = ({ surveyFn, recordFn, queries }) => {
+export const testRecordExpressions = ({ surveyFn, recordFn, queries }) =>
   _testExpressions({
     queries,
     expressionEvaluator: ({ nodePath, query }) => {
@@ -42,4 +43,19 @@ export const testRecordExpressions = ({ surveyFn, recordFn, queries }) => {
       return RecordExpressionParser.evalNodeQuery(survey, record, node, query)
     },
   })
-}
+
+export const testNodeDefExpressions = ({ surveyFn, queries }) =>
+  _testExpressions({
+    queries,
+    expressionEvaluator: ({ nodePath, query }) => {
+      const survey = surveyFn()
+      const nodeDefCurrent = Survey.getNodeDefByName(nodePath || 'cluster_id')(survey)
+      const validationResult = NodeDefExpressionValidator.validate({
+        survey,
+        nodeDefCurrent,
+        exprString: query,
+        selfReferenceAllowed: true,
+      })
+      return validationResult === null
+    },
+  })

--- a/test/utils/nodeDefExpressionUtils.js
+++ b/test/utils/nodeDefExpressionUtils.js
@@ -15,12 +15,12 @@ const _expectResult = ({ result, resultExpected }) => {
 }
 
 const _testExpressions = ({ queries, expressionEvaluator }) =>
-  queries.forEach(({ q, r, n, e }) => {
+  queries.forEach(({ q, r, n = null, e = null, s = true }) => {
     const testTitle = `${q}${n ? ` (${n})` : ''}`
 
     it(testTitle, () => {
       try {
-        const result = expressionEvaluator({ nodePath: n, query: q })
+        const result = expressionEvaluator({ nodePath: n, query: q, selfReferenceAllowed: s })
         _expectResult({ result, resultExpected: r })
       } catch (error) {
         if (e) {
@@ -47,14 +47,14 @@ export const testRecordExpressions = ({ surveyFn, recordFn, queries }) =>
 export const testNodeDefExpressions = ({ surveyFn, queries }) =>
   _testExpressions({
     queries,
-    expressionEvaluator: ({ nodePath, query }) => {
+    expressionEvaluator: ({ nodePath, query, selfReferenceAllowed }) => {
       const survey = surveyFn()
       const nodeDefCurrent = Survey.getNodeDefByName(nodePath || 'cluster_id')(survey)
       const validationResult = NodeDefExpressionValidator.validate({
         survey,
         nodeDefCurrent,
         exprString: query,
-        selfReferenceAllowed: true,
+        selfReferenceAllowed,
       })
       return validationResult === null
     },


### PR DESCRIPTION
## Related Issue

Resolves #1398

## Brief description of the changes proposed an/or how the issue(s) has(have) been solved.

This pull request allows the use of native js object properties and functions (such as String.toLowerCase, Number.toFixed etc) on attribute values.

## How has this been tested

Unit tests have been created to test the evaluation of expressions accessing native properties.
Also a set of unit tests on the NodeDefExpressionValidator module has been added.
The use of the current node def has been allowed in cases of complex expressions accessing sibling entities.
Also, I've moved the creation of the test survey and record to a separate file.

##### Do you consider this PR needs further testing?
- [x] No
- [ ] Yes

## Types of changes

- [ ] Docs change 
- [ ] Refactoring 
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Disclaimer

The check if the current node is being referenced by the expression could be improved, even if it looks quite difficult.
Now, when we are defining an expression for a Default Value (self reference not allowed), expressions like this won't be allowed: plot_id + 1 (current node def = plot_id)
But this expression will be allowed, even if at runtime it will refer the current node (plot_id): parent(parent(plot_id)).plot[index(parent(plot_id))].plot_id