### PR TITLE
Expressions: allow usage of global objects constructors

### DIFF
--- a/core/expressionParser/helpers/evaluator/callEval.js
+++ b/core/expressionParser/helpers/evaluator/callEval.js
@@ -1,0 +1,96 @@
+import SystemError from '@core/systemError'
+
+import { functionImplementations } from '../functionImplementations'
+import { functions } from '../functions'
+import { types } from '../types'
+import { globalIdentifierEval } from './globalIdentifierEval'
+
+const _callMemberEval = ({ evalExpression, expr, ctx }) => {
+  // Arguments is a reserved word in strict mode
+  const { callee, arguments: exprArgs } = expr
+
+  // global function (e.g. Math.round(...))
+  const fn = evalExpression(callee, ctx)
+  if (fn) {
+    const args = exprArgs.map((arg) => evalExpression(arg, ctx))
+    return fn(...args)
+  }
+  return null
+}
+
+const _callIdentifierCustomFunctionEval = ({ evalExpression, expr, ctx }) => {
+  // Arguments is a reserved word in strict mode
+  const { callee, arguments: exprArgs } = expr
+  const { functions: functionsCtx = {} } = ctx
+
+  const { name: fnName } = callee
+  const numArgs = exprArgs.length
+
+  const functionInfo = functions[fnName]
+
+  const { minArity, maxArity, evaluateArgsToNodes = false } = functionInfo
+
+  if (numArgs < minArity) {
+    throw new SystemError('functionHasTooFewArguments', {
+      fnName,
+      minArgs: minArity,
+      numArgs,
+    })
+  }
+
+  const maxArityIsDefined = maxArity !== undefined
+  const maxArityIsInfinite = maxArity < 0
+  if (maxArityIsDefined && !maxArityIsInfinite && numArgs > maxArity) {
+    throw new SystemError('functionHasTooManyArguments', {
+      fnName,
+      maxArgs: maxArity,
+      numArgs,
+    })
+  }
+
+  const args = exprArgs.map((arg) => evalExpression(arg, { ...ctx, evaluateToNode: evaluateArgsToNodes }))
+
+  const fn = functionsCtx[fnName] || functionImplementations[fnName]
+
+  // Currently there are no side effects from function evaluation so it's
+  // safe to call the function even when we're just parsing the expression
+  // to find all identifiers being used.
+  return fn(...args)
+}
+
+const _callIdentifierEval = ({ evalExpression, expr, ctx }) => {
+  // Arguments is a reserved word in strict mode
+  const { callee, arguments: exprArgs } = expr
+  const { node: nodeContext } = ctx
+
+  const { name: fnName } = callee
+
+  const functionInfo = functions[fnName]
+  if (functionInfo) {
+    // The function is among the Arena custom functions.
+    return _callIdentifierCustomFunctionEval({ evalExpression, functionInfo, expr, ctx })
+  }
+  // identifier is a global object
+  const globalFn = globalIdentifierEval({ identifierName: fnName, nodeContext })
+  if (globalFn !== null) {
+    const args = exprArgs.map((arg) => evalExpression(arg, ctx))
+    return globalFn(...args)
+  }
+
+  throw new SystemError('undefinedFunction', { fnName })
+}
+
+export const callEval = ({ evalExpression }) => (expr, ctx) => {
+  const { callee } = expr
+
+  switch (callee.type) {
+    case types.MemberExpression:
+      return _callMemberEval({ evalExpression, expr, ctx })
+    case types.Identifier:
+      return _callIdentifierEval({ evalExpression, expr, ctx })
+    default:
+      // No complex expressions may be put in place of a function body.
+      // Only a plain identifier is allowed.
+      throw new SystemError('invalidSyntax', { fnType: callee.type })
+  }
+}

--- a/core/expressionParser/helpers/evaluator/globalIdentifierEval.js
+++ b/core/expressionParser/helpers/evaluator/globalIdentifierEval.js
@@ -1,0 +1,24 @@
+import SystemError from '@core/systemError'
+
+const globalObjects = {
+  Array,
+  Boolean,
+  Date,
+  Math,
+  Number,
+  String,
+}
+
+export const globalIdentifierEval = ({ identifierName, nodeContext }) => {
+  if (identifierName in globalObjects) {
+    return globalObjects[identifierName]
+  }
+  if (Object.values(globalObjects).includes(nodeContext)) {
+    const result = nodeContext[identifierName]
+    if (!result) {
+      throw new SystemError('undefinedFunction', { fnName: identifierName })
+    }
+    return result
+  }
+  return null
+}

--- a/core/expressionParser/helpers/evaluator/index.js
+++ b/core/expressionParser/helpers/evaluator/index.js
@@ -1,0 +1,2 @@
+export { evalExpression } from './evaluator'
+export { globalIdentifierEval } from './globalIdentifierEval'

--- a/core/record/recordExpressionParser/identifierEval.js
+++ b/core/record/recordExpressionParser/identifierEval.js
@@ -110,23 +110,23 @@ const _getReferencedNodes = ({ survey, record, node, nodeDefReferenced }) => {
   return []
 }
 
-export const identifierEval = (survey, record) => (expr, { node: exprContext, evaluateToNode }) => {
+export const identifierEval = (survey, record) => (expr, { node: nodeContext, evaluateToNode }) => {
   const exprName = Expression.getName(expr)
 
   // identifier is global object
-  const globalIdentifierEvalResult = Expression.globalIdentifierEval({ identifierName: exprName, exprContext })
+  const globalIdentifierEvalResult = Expression.globalIdentifierEval({ identifierName: exprName, nodeContext })
   if (globalIdentifierEvalResult !== null) {
     return globalIdentifierEvalResult
   }
 
   // identifier is a native property or function (e.g. String.length or String.toUpperCase())
-  const prop = exprContext[exprName]
+  const prop = nodeContext[exprName]
   if (prop !== undefined) {
-    return prop instanceof Function ? prop.bind(exprContext) : prop
+    return prop instanceof Function ? prop.bind(nodeContext) : prop
   }
 
   // identifier references a node
-  const node = exprContext
+  const node = nodeContext
   const nodeDefCtx = Survey.getNodeDefByUuid(Node.getNodeDefUuid(node))(survey)
   const nodeDefReferenced = Survey.getNodeDefByName(exprName)(survey)
 

--- a/core/survey/nodeDefExpressionValidator/identifierEval.js
+++ b/core/survey/nodeDefExpressionValidator/identifierEval.js
@@ -40,22 +40,22 @@ const _getReachableNodeDefs = (survey, nodeDefContext) => {
 }
 
 export const identifierEval = ({ survey, nodeDefCurrent }) => (expr, ctx) => {
-  const { node: exprContext, selfReferenceAllowed = true } = ctx
+  const { node: nodeContext, selfReferenceAllowed = true } = ctx
 
   const exprName = Expression.getName(expr)
 
-  const globalIdentifierEvalResult = Expression.globalIdentifierEval({ identifierName: exprName, exprContext })
+  const globalIdentifierEvalResult = Expression.globalIdentifierEval({ identifierName: exprName, nodeContext })
   if (globalIdentifierEvalResult !== null) {
     return globalIdentifierEvalResult
   }
 
   // identifier is a native property or function (e.g. String.length or String.toUpperCase())
-  if (NodeNativeProperties.hasNativeProperty({ nodeDefOrValue: exprContext, propName: exprName })) {
-    return NodeNativeProperties.evalNodeDefProperty({ nodeDefOrValue: exprContext, propName: exprName })
+  if (NodeNativeProperties.hasNativeProperty({ nodeDefOrValue: nodeContext, propName: exprName })) {
+    return NodeNativeProperties.evalNodeDefProperty({ nodeDefOrValue: nodeContext, propName: exprName })
   }
 
   // identifier references a node
-  const reachableNodeDefs = _getReachableNodeDefs(survey, exprContext)
+  const reachableNodeDefs = _getReachableNodeDefs(survey, nodeContext)
 
   const def = reachableNodeDefs.find((x) => NodeDef.getName(x) === exprName)
 

--- a/test/unit/tests/002recordExpressionParser.test.js
+++ b/test/unit/tests/002recordExpressionParser.test.js
@@ -127,6 +127,12 @@ describe('RecordExpressionParser Test', () => {
     { q: 'gps_model.substring(4,7)', r: '123' },
     { q: 'gps_model.length', r: 11 },
     { q: 'gps_model[1]', r: 'B' },
+    // global objects (constructors)
+    { q: 'Boolean(cluster_id)', r: true },
+    { q: 'Boolean(remarks)', r: false },
+    { q: 'Date.parse(Date()) <= Date.now()', r: true },
+    { q: 'Number(remarks)', r: 0 },
+    { q: 'String(cluster_id)', r: '12' },
   ]
 
   NodeDefExpressionUtils.testRecordExpressions({ surveyFn: () => survey, recordFn: () => record, queries })

--- a/test/unit/tests/007nodeDefExpressionValidator.test.js
+++ b/test/unit/tests/007nodeDefExpressionValidator.test.js
@@ -66,6 +66,13 @@ describe('NodeDefExpressionValidator Test', () => {
     { q: 'gps_model.substring(4,7)', r: true },
     { q: 'gps_model.length', r: true },
     { q: 'gps_model[1]', r: true },
+    // global objects (constructors)
+    { q: 'Boolean(cluster_id)', r: true },
+    { q: 'Boolean(remarks)', r: true },
+    { q: 'Date.parse(Date()) <= Date.now()', r: true },
+    { q: 'Number(remarks)', r: true },
+    { q: 'String(cluster_id)', r: true },
+    { q: 'Strings(cluster_id)', r: false },
   ]
 
   NodeDefExpressionUtils.testNodeDefExpressions({ surveyFn: () => survey, queries })


### PR DESCRIPTION
## Related Issue

Resolves #1369

## Brief description of the changes proposed an/or how the issue(s) has(have) been solved.

With this pull request it will be possible to use expressions like String(123), Number('1'), Boolean(attribute_name) etc to convert values into different types.
The bigger change is in the evaluation of the "call" expression; I've splitted the evaluator.js module into several modules, moving the code of the old function "callEval" into a separate file. Now the evaluation of the function name in callEval takes into account the global objects.

## How has this been tested

Unit tests have been added.

##### Do you consider this PR needs further testing?
- [x] No
- [ ] Yes

## Types of changes

- [ ] Docs change 
- [ ] Refactoring 
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
