### PR TITLE
Expressions: allow use of composite attribute members

### DIFF
--- a/common/model/db/tables/node/select.js
+++ b/common/model/db/tables/node/select.js
@@ -45,9 +45,9 @@ export function getSelect(params) {
   _addUuidEqualCondition(this.columnNodeDefUuid, nodeDefUuid)
 
   const _getColumnValueProp = (keyProp) => `${this.columnValue}->>'${keyProp}'`
-  const columnTaxonUuid = _getColumnValueProp(Node.valuePropKeys.taxonUuid)
-  const columnCategoryItemUuid = _getColumnValueProp(Node.valuePropKeys.itemUuid)
-  const columnTaxonVernacularNameUuid = _getColumnValueProp(Node.valuePropKeys.vernacularNameUuid)
+  const columnTaxonUuid = _getColumnValueProp(Node.valuePropsTaxon.taxonUuid)
+  const columnCategoryItemUuid = _getColumnValueProp(Node.valuePropsTaxon.itemUuid)
+  const columnTaxonVernacularNameUuid = _getColumnValueProp(Node.valuePropsTaxon.vernacularNameUuid)
 
   const query = `SELECT ${this.columns},
         CASE

--- a/core/expressionParser/expression.js
+++ b/core/expressionParser/expression.js
@@ -55,7 +55,7 @@ export const { isValid } = ExpressionUtils
 const isType = (type) => R.propEq('type', type)
 
 // Return true if the nodeDef can be used in expressions and false otherwise
-export const isValidExpressionType = (nodeDef) => !NodeDef.isCoordinate(nodeDef) && !NodeDef.isFile(nodeDef)
+export const isValidExpressionType = (nodeDef) => !NodeDef.isFile(nodeDef)
 
 export const isLiteral = isType(types.Literal)
 export const isCompound = isType(types.Compound)

--- a/core/record/node.js
+++ b/core/record/node.js
@@ -32,30 +32,45 @@ export const metaKeys = {
   hierarchyCode: 'hCode', // Hierarchy of code attribute ancestors (according to the parent code defs specified)
 }
 
-export const valuePropKeys = {
-  // Generic code (can be used by taxon or categoryItem)
+export const valuePropsCode = {
   code: 'code',
-
-  // Code
   itemUuid: 'itemUuid',
   label: 'label',
+}
 
-  // Coordinate
+export const valuePropsCoordinate = {
   x: 'x',
   y: 'y',
   srs: 'srs',
+}
 
-  // File
+export const valuePropsFile = {
   fileUuid: 'fileUuid',
   fileName: 'fileName',
   fileSize: 'fileSize',
-
-  // Taxon
-  taxonUuid: 'taxonUuid',
-  vernacularNameUuid: 'vernacularNameUuid',
-  scientificName: 'scientificName',
-  vernacularName: 'vernacularName',
 }
+
+export const valuePropsTaxon = {
+  code: 'code',
+  itemUuid: 'itemUuid',
+  scientificName: 'scientificName',
+  taxonUuid: 'taxonUuid',
+  vernacularName: 'vernacularName',
+  vernacularNameUuid: 'vernacularNameUuid',
+}
+
+/**
+ * Props of node value indexed by node def type.
+ * The node definitions here are only the ones of "composite" attributes.
+ */
+export const valuePropsByType = {
+  [NodeDef.nodeDefType.code]: valuePropsCode,
+  [NodeDef.nodeDefType.coordinate]: valuePropsCoordinate,
+  [NodeDef.nodeDefType.file]: valuePropsFile,
+  [NodeDef.nodeDefType.taxon]: valuePropsTaxon,
+}
+
+export const isValueProp = ({ nodeDef, prop }) => Boolean(R.path([NodeDef.getType(nodeDef), prop])(valuePropsByType))
 
 //
 // ======
@@ -164,12 +179,13 @@ export const isValueBlank = (node) => {
 // ====== Node Value extractor
 
 // Code
-export const getCategoryItemUuid = getValueProp(valuePropKeys.itemUuid)
+export const getCategoryItemUuid = getValueProp(valuePropsCode.itemUuid)
 
 // Coordinate
-export const getCoordinateX = getValueProp(valuePropKeys.x)
-export const getCoordinateY = getValueProp(valuePropKeys.y)
-export const getCoordinateSrs = (node, defaultValue = null) => getValueProp(valuePropKeys.srs, defaultValue)(node)
+export const getCoordinateX = getValueProp(valuePropsCoordinate.x)
+export const getCoordinateY = getValueProp(valuePropsCoordinate.y)
+export const getCoordinateSrs = (node, defaultValue = null) =>
+  getValueProp(valuePropsCoordinate.srs, defaultValue)(node)
 
 // Date
 const _getDatePart = (index) => R.pipe(R.partialRight(getValue, ['--']), R.split('-'), R.prop(index), StringUtils.trim)
@@ -180,14 +196,14 @@ export const getDateCreated = R.prop(keys.dateCreated)
 export const getDateModified = R.prop(keys.dateModified)
 
 // File
-export const getFileName = getValueProp(valuePropKeys.fileName, '')
-export const getFileUuid = getValueProp(valuePropKeys.fileUuid, '')
+export const getFileName = getValueProp(valuePropsFile.fileName, '')
+export const getFileUuid = getValueProp(valuePropsFile.fileUuid, '')
 
 // Taxon
-export const getTaxonUuid = getValueProp(valuePropKeys.taxonUuid)
-export const getVernacularNameUuid = getValueProp(valuePropKeys.vernacularNameUuid)
-export const getScientificName = getValueProp(valuePropKeys.scientificName, '')
-export const getVernacularName = getValueProp(valuePropKeys.vernacularName, '')
+export const getTaxonUuid = getValueProp(valuePropsTaxon.taxonUuid)
+export const getVernacularNameUuid = getValueProp(valuePropsTaxon.vernacularNameUuid)
+export const getScientificName = getValueProp(valuePropsTaxon.scientificName, '')
+export const getVernacularName = getValueProp(valuePropsTaxon.vernacularName, '')
 
 // Time
 const _getTimePart = (index) => R.pipe(R.partialRight(getValue, [':']), R.split(':'), R.prop(index), StringUtils.trim)

--- a/core/record/node.js
+++ b/core/record/node.js
@@ -86,7 +86,7 @@ export const getRecordUuid = R.prop(keys.recordUuid)
 
 export const getValue = (node = {}, defaultValue = {}) => R.propOr(defaultValue, keys.value, node)
 
-const getValueProp = (prop, defaultValue = null) => R.pipe(getValue, R.propOr(defaultValue, prop))
+export const getValueProp = (prop, defaultValue = null) => R.pipe(getValue, R.propOr(defaultValue, prop))
 
 export const { getNodeDefUuid } = ObjectUtils
 

--- a/core/record/recordExpressionValueConverter.js
+++ b/core/record/recordExpressionValueConverter.js
@@ -31,7 +31,7 @@ const _toCode = ({ survey, record, nodeCtx, valueExpr }) => {
 
   const { itemUuid } = Survey.getCategoryItemUuidAndCodeHierarchy(survey, nodeDef, record, parentNode, code)(survey)
 
-  return itemUuid ? { [Node.valuePropKeys.itemUuid]: itemUuid } : null
+  return itemUuid ? { [Node.valuePropsCode.itemUuid]: itemUuid } : null
 }
 
 const _toDateTime = ({ valueExpr, format, formatsFrom = [DateUtils.formats.datetimeDefault] }) => {
@@ -52,7 +52,7 @@ const _toTaxon = ({ survey, nodeCtx, valueExpr }) => {
   const nodeDef = Survey.getNodeDefByUuid(Node.getNodeDefUuid(nodeCtx))(survey)
   const taxonUuid = Survey.getTaxonUuid(nodeDef, taxonCode)(survey)
 
-  return taxonUuid ? { [Node.valuePropKeys.taxonUuid]: taxonUuid } : null
+  return taxonUuid ? { [Node.valuePropsTaxon.taxonUuid]: taxonUuid } : null
 }
 
 const _valueExprToValueNodeFns = {

--- a/core/survey/nodeDef.js
+++ b/core/survey/nodeDef.js
@@ -130,16 +130,18 @@ export const isEntityOrMultiple = (nodeDef) => isEntity(nodeDef) || isMultiple(n
 export const isAttribute = R.pipe(isEntity, R.not)
 export const isSingleAttribute = (nodeDef) => isAttribute(nodeDef) && isSingle(nodeDef)
 export const isMultipleAttribute = (nodeDef) => isAttribute(nodeDef) && isMultiple(nodeDef)
+export const isAttributeComposite = (nodeDef) =>
+  [nodeDefType.coordinate, nodeDefType.file, nodeDefType.taxon].includes(getType(nodeDef))
 
-export const isText = isType(nodeDefType.text)
 export const isBoolean = isType(nodeDefType.boolean)
-export const isDate = isType(nodeDefType.date)
 export const isCode = isType(nodeDefType.code)
 export const isCoordinate = isType(nodeDefType.coordinate)
+export const isDate = isType(nodeDefType.date)
 export const isDecimal = isType(nodeDefType.decimal)
 export const isFile = isType(nodeDefType.file)
 export const isInteger = isType(nodeDefType.integer)
 export const isTaxon = isType(nodeDefType.taxon)
+export const isText = isType(nodeDefType.text)
 
 export const isReadOnly = getProp(propKeys.readOnly, false)
 

--- a/core/survey/nodeDefExpressionValidator/identifierEval.js
+++ b/core/survey/nodeDefExpressionValidator/identifierEval.js
@@ -1,6 +1,7 @@
 import * as Validation from '@core/validation/validation'
 import * as Survey from '@core/survey/survey'
 import * as NodeDef from '@core/survey/nodeDef'
+import * as Node from '@core/record/node'
 import * as NodeNativeProperties from '@core/survey/nodeDefExpressionNativeProperties'
 import * as Expression from '@core/expressionParser/expression'
 import Queue from '@core/queue'
@@ -49,9 +50,14 @@ export const identifierEval = ({ survey, nodeDefCurrent }) => (expr, ctx) => {
     return globalIdentifierEvalResult
   }
 
-  // identifier is a native property or function (e.g. String.length or String.toUpperCase())
+  // check if identifier is a native property or function (e.g. String.length or String.toUpperCase())
   if (NodeNativeProperties.hasNativeProperty({ nodeDefOrValue: nodeContext, propName: exprName })) {
     return NodeNativeProperties.evalNodeDefProperty({ nodeDefOrValue: nodeContext, propName: exprName })
+  }
+
+  // check if identifier is a composite attribute value prop
+  if (NodeDef.isAttribute(nodeContext) && Node.isValueProp({ nodeDef: nodeContext, prop: exprName })) {
+    return nodeContext
   }
 
   // identifier references a node

--- a/server/modules/analysis/service/rChain/rFile/system/dfResults.js
+++ b/server/modules/analysis/service/rChain/rFile/system/dfResults.js
@@ -107,7 +107,7 @@ export default class DfResults {
         const query = `
             SELECT 
                 r.*,
-                "{""${Node.valuePropKeys.itemUuid}"": """ || c.uuid || """, ""${Node.valuePropKeys.code}"": """ || c.code || """, ""${Node.valuePropKeys.label}"": """ || c.label || """}" AS ${nodeVarName}
+                "{""${Node.valuePropsCode.itemUuid}"": """ || c.uuid || """, ""${Node.valuePropsCode.code}"": """ || c.code || """, ""${Node.valuePropsCode.label}"": """ || c.label || """}" AS ${nodeVarName}
             FROM ${this.name} r
             LEFT OUTER JOIN ${categoryTempVar} c
             ON r.${nodeTmpVarName} = c.code  

--- a/server/modules/collectImport/service/collectImport/dataImportJobs/collectAttributeValueExtractor.js
+++ b/server/modules/collectImport/service/collectImport/dataImportJobs/collectAttributeValueExtractor.js
@@ -39,7 +39,7 @@ const extractCodeValueAndMeta = (survey, nodeDef, record, node) => (collectNode)
     return itemUuid
       ? {
           value: {
-            [Node.valuePropKeys.itemUuid]: itemUuid,
+            [Node.valuePropsCode.itemUuid]: itemUuid,
           },
           meta: {
             [Node.metaKeys.hierarchyCode]: hierarchyCode,
@@ -59,9 +59,9 @@ const extractCoordinateValueAndMeta = (collectNode) => {
 
     return {
       value: {
-        [Node.valuePropKeys.x]: x,
-        [Node.valuePropKeys.y]: y,
-        [Node.valuePropKeys.srs]: srsId,
+        [Node.valuePropsCoordinate.x]: x,
+        [Node.valuePropsCoordinate.y]: y,
+        [Node.valuePropsCoordinate.srs]: srsId,
       },
     }
   }
@@ -102,9 +102,9 @@ const extractFileValueAndMeta = (survey, node, collectSurveyFileZip, collectNode
 
     return {
       value: {
-        [Node.valuePropKeys.fileUuid]: fileUuid,
-        [Node.valuePropKeys.fileName]: fileName,
-        [Node.valuePropKeys.fileSize]: fileSize,
+        [Node.valuePropsFile.fileUuid]: fileUuid,
+        [Node.valuePropsFile.fileName]: fileName,
+        [Node.valuePropsFile.fileSize]: fileSize,
       },
     }
   }
@@ -120,19 +120,19 @@ const extractTaxonValueAndMeta = (survey, nodeDef) => (collectNode) => {
 
   if (taxonUuid) {
     const value = {
-      [Node.valuePropKeys.taxonUuid]: taxonUuid,
+      [Node.valuePropsTaxon.taxonUuid]: taxonUuid,
     }
 
     if (code === Taxon.unlistedCode) {
-      value[Node.valuePropKeys.scientificName] = scientificName
+      value[Node.valuePropsTaxon.scientificName] = scientificName
     }
 
     if (vernacularName) {
       const vernacularNameUuid = Survey.getTaxonVernacularNameUuid(nodeDef, code, vernacularName)(survey)
       if (vernacularNameUuid) {
-        value[Node.valuePropKeys.vernacularNameUuid] = vernacularNameUuid
+        value[Node.valuePropsTaxon.vernacularNameUuid] = vernacularNameUuid
       } else {
-        value[Node.valuePropKeys.vernacularName] = vernacularName
+        value[Node.valuePropsTaxon.vernacularName] = vernacularName
       }
     }
 

--- a/server/modules/record/repository/nodeRepository.js
+++ b/server/modules/record/repository/nodeRepository.js
@@ -47,15 +47,15 @@ const _getNodeSelectQuery = (surveyId, draft) => {
     LEFT OUTER JOIN
         ${schema}.category_item c
     ON
-        (n.value->>'${Node.valuePropKeys.itemUuid}')::uuid = c.uuid
+        (n.value->>'${Node.valuePropsCode.itemUuid}')::uuid = c.uuid
     LEFT OUTER JOIN
         ${schema}.taxon t
     ON
-        (n.value->>'${Node.valuePropKeys.taxonUuid}')::uuid = t.uuid
+        (n.value->>'${Node.valuePropsTaxon.taxonUuid}')::uuid = t.uuid
     LEFT OUTER JOIN
         ${schema}.taxon_vernacular_name v
     ON
-        (n.value->>'${Node.valuePropKeys.vernacularNameUuid}')::uuid = v.uuid`
+        (n.value->>'${Node.valuePropsTaxon.vernacularNameUuid}')::uuid = v.uuid`
 }
 
 // ============== CREATE

--- a/test/unit/tests/002recordExpressionParser.test.js
+++ b/test/unit/tests/002recordExpressionParser.test.js
@@ -133,6 +133,12 @@ describe('RecordExpressionParser Test', () => {
     { q: 'Date.parse(Date()) <= Date.now()', r: true },
     { q: 'Number(remarks)', r: 0 },
     { q: 'String(cluster_id)', r: '12' },
+    // composite attribute members
+    { q: 'cluster_location.x', r: 41.883012 },
+    { q: 'cluster_location.y', r: 12.489056 },
+    { q: 'cluster_location.srs', r: 'EPSG:4326' },
+    { q: 'plot[0].tree[0].tree_species.code', r: 'ACA' },
+    { q: 'plot[0].tree[0].tree_species.scientificName', r: 'Acacia sp.' },
   ]
 
   NodeDefExpressionUtils.testRecordExpressions({ surveyFn: () => survey, recordFn: () => record, queries })

--- a/test/unit/tests/007nodeDefExpressionValidator.test.js
+++ b/test/unit/tests/007nodeDefExpressionValidator.test.js
@@ -73,6 +73,12 @@ describe('NodeDefExpressionValidator Test', () => {
     { q: 'Number(remarks)', r: true },
     { q: 'String(cluster_id)', r: true },
     { q: 'Strings(cluster_id)', r: false },
+    // composite attributes
+    { q: 'cluster_location.x', r: true },
+    { q: 'cluster_location.srs', r: true },
+    { q: 'cluster_location.xyz', r: false },
+    { q: 'plot[0].tree[0].tree_species.code', r: true },
+    { q: 'plot[0].tree[0].tree_species.scientificName', r: true },
   ]
 
   NodeDefExpressionUtils.testNodeDefExpressions({ surveyFn: () => survey, queries })

--- a/test/utils/dataTest/dataTest.js
+++ b/test/utils/dataTest/dataTest.js
@@ -1,4 +1,5 @@
 import * as NodeDef from '@core/survey/nodeDef'
+import * as Node from '@core/record/node'
 
 import * as SB from '../surveyBuilder'
 import * as RB from '../recordBuilder'
@@ -36,6 +37,11 @@ export const createTestRecord = ({ user, survey }) =>
     RB.entity(
       'cluster',
       RB.attribute('cluster_id', 12),
+      RB.attribute('cluster_location', {
+        [Node.valuePropsCoordinate.srs]: 'EPSG:4326',
+        [Node.valuePropsCoordinate.x]: 41.883012,
+        [Node.valuePropsCoordinate.y]: 12.489056,
+      }),
       RB.attribute('cluster_distance', 18),
       RB.attribute('visit_date', '2021-01-01'),
       RB.attribute('gps_model', 'ABC-123-xyz'),
@@ -45,7 +51,16 @@ export const createTestRecord = ({ user, survey }) =>
         RB.attribute('plot_id', 1),
         RB.attribute('plot_multiple_number', 10),
         RB.attribute('plot_multiple_number', 20),
-        RB.entity('tree', RB.attribute('tree_id', 1), RB.attribute('tree_height', 10), RB.attribute('dbh', 7)),
+        RB.entity(
+          'tree',
+          RB.attribute('tree_id', 1),
+          RB.attribute('tree_height', 10),
+          RB.attribute('dbh', 7),
+          RB.attribute('tree_species', {
+            [Node.valuePropsTaxon.code]: 'ACA',
+            [Node.valuePropsTaxon.scientificName]: 'Acacia sp.',
+          })
+        ),
         RB.entity('tree', RB.attribute('tree_id', 2), RB.attribute('tree_height', 11), RB.attribute('dbh', 10.123))
       ),
       RB.entity(

--- a/test/utils/dataTest/dataTest.js
+++ b/test/utils/dataTest/dataTest.js
@@ -9,6 +9,7 @@ export const createTestSurvey = ({ user }) =>
     SB.entity(
       'cluster',
       SB.attribute('cluster_id', NodeDef.nodeDefType.integer).key(),
+      SB.attribute('cluster_location', NodeDef.nodeDefType.coordinate),
       SB.attribute('cluster_distance', NodeDef.nodeDefType.integer),
       SB.attribute('visit_date', NodeDef.nodeDefType.date),
       SB.attribute('gps_model', NodeDef.nodeDefType.text),
@@ -21,7 +22,8 @@ export const createTestSurvey = ({ user }) =>
           'tree',
           SB.attribute('tree_id', NodeDef.nodeDefType.integer).key(),
           SB.attribute('tree_height', NodeDef.nodeDefType.integer),
-          SB.attribute('dbh', NodeDef.nodeDefType.decimal)
+          SB.attribute('dbh', NodeDef.nodeDefType.decimal),
+          SB.attribute('tree_species', NodeDef.nodeDefType.taxon)
         ).multiple()
       ).multiple()
     )

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/types/NodeDefCode/NodeDefCode.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/types/NodeDefCode/NodeDefCode.js
@@ -58,7 +58,7 @@ const NodeDefCode = (props) => {
         ? nodes[0]
         : Node.newNode(NodeDef.getUuid(nodeDef), Node.getRecordUuid(parentNode), parentNode)
 
-    const value = { [Node.valuePropKeys.itemUuid]: CategoryItem.getUuid(item) }
+    const value = { [Node.valuePropsCode.itemUuid]: CategoryItem.getUuid(item) }
     const meta = { [Node.metaKeys.hierarchyCode]: codeUuidsHierarchy }
     const refData = { [NodeRefData.keys.categoryItem]: item }
 

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefFile.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefFile.js
@@ -12,9 +12,9 @@ import NodeDeleteButton from '../nodeDeleteButton'
 
 const handleFileChange = (nodeDef, node, file, updateNode) => {
   const value = {
-    [Node.valuePropKeys.fileUuid]: uuidv4(),
-    [Node.valuePropKeys.fileName]: file.name,
-    [Node.valuePropKeys.fileSize]: file.size,
+    [Node.valuePropsFile.fileUuid]: uuidv4(),
+    [Node.valuePropsFile.fileName]: file.name,
+    [Node.valuePropsFile.fileSize]: file.size,
   }
   updateNode(nodeDef, node, value, file)
 }

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefTaxon.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefTaxon.js
@@ -17,7 +17,7 @@ import * as StringUtils from '@core/stringUtils'
 import { SurveyState } from '@webapp/store/survey'
 import NodeDefTaxonInputField from './nodeDefTaxonInputField'
 
-const { code, scientificName, vernacularName, vernacularNameUuid, taxonUuid } = Node.valuePropKeys
+const { code, scientificName, vernacularName, vernacularNameUuid, taxonUuid } = Node.valuePropsTaxon
 
 const selectionDefault = {
   [code]: '',

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefTaxonInputField.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefTaxonInputField.js
@@ -71,11 +71,11 @@ NodeDefTaxonInputField.defaultProps = {
   canEditRecord: false,
   readOnly: false,
 
-  field: Node.valuePropKeys.code,
+  field: Node.valuePropsTaxon.code,
   selection: {
-    [Node.valuePropKeys.code]: '',
-    [Node.valuePropKeys.scientificName]: '',
-    [Node.valuePropKeys.vernacularName]: '',
+    [Node.valuePropsTaxon.code]: '',
+    [Node.valuePropsTaxon.scientificName]: '',
+    [Node.valuePropsTaxon.vernacularName]: '',
   },
   onChangeTaxon: null, // Function to call when the taxon value changed
   onChangeSelectionField: null, // Function to call when local selection changes


### PR DESCRIPTION
## Related Issue

Resolves #1128

## Brief description of the changes proposed an/or how the issue(s) has(have) been solved.

The changes are in the way an "identifier" is evaluated: if it is a composite attribute value member, than the corresponding value is returned.
I've splitted the valuePropKeys into several objects, depending on the type of attribute (and the use of that constant has been updated accordingly).

## How has this been tested

Unit tests for expression validator and evaluator have been added.

##### Do you consider this PR needs further testing?
- [ ] No
- [x] Yes

## Types of changes

- [ ] Docs change 
- [ ] Refactoring 
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Disclaimer

This pull request changes the way in which the value of a "composite" attribute is returned by the expression (now in this case the value object is returned, instead of a string representation of it).
Accessing members of Date and Time attributes will be allowed in the next pull request.