### PR TITLE
Show node def edit buttons only on mouse over

### DIFF
--- a/test/e2e/tests/_formDesigner/index.js
+++ b/test/e2e/tests/_formDesigner/index.js
@@ -3,9 +3,22 @@ import { editNodeDefDetails } from '../_nodeDefDetails'
 import { getAtomicAttributeKeys, tree } from '../../mock/nodeDefs'
 import { dragAndDrop } from '../utils/dragDrop'
 
+const makeEditButtonsVisible = async ({ nodeDefName }) => {
+  const wrapperSelector = getSelector(DataTestId.surveyForm.nodeDefWrapper(nodeDefName))
+  await page.waitForSelector(wrapperSelector)
+  const wrapperEl = await page.$(wrapperSelector)
+  await expect(wrapperEl).not.toBeNull()
+
+  // move mouse inside node def wrapper to make edit buttons appear
+  const boundingBox = await wrapperEl.boundingBox()
+  await page.mouse.move(boundingBox.x, boundingBox.y)
+  await page.mouse.move(boundingBox.x + boundingBox.width / 2, boundingBox.y + boundingBox.height / 2, { steps: 2 })
+}
+
 // ==== add
 export const addNodeDef = (nodeDefParent, nodeDefChild, editDetails = true) => {
   test(`${nodeDefParent.label} -> ${nodeDefChild.label} add`, async () => {
+    await makeEditButtonsVisible({ nodeDefName: nodeDefParent.name })
     await page.click(getSelector(DataTestId.surveyForm.nodeDefAddChildBtn(nodeDefParent.name), 'button'))
     await Promise.all([page.waitForNavigation(), page.click(`text="${nodeDefChild.type}"`)])
   })
@@ -15,7 +28,7 @@ export const addNodeDef = (nodeDefParent, nodeDefChild, editDetails = true) => {
   if (nodeDefChild.type === 'entity') {
     test(`Expand ${nodeDefChild.name} table`, async () => {
       // expand table by 3 columns and 4 rows
-      const entityEl = await page.$(getSelector(tree.name))
+      const entityEl = await page.$(getSelector(DataTestId.surveyForm.nodeDefWrapper(tree.name)))
       const entityBBox = await entityEl.boundingBox()
       await dragAndDrop(
         entityBBox.x + entityBBox.width - 5,
@@ -48,10 +61,12 @@ export const addNodeDefSubPage = (nodeDefParent, nodeDefChild) => {
 // ==== edit
 export const editNodeDef = (formName, nodeDef, editDetails = true) => {
   test(`${nodeDef.label} edit`, async () => {
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(getSelector(DataTestId.surveyForm.nodeDefEditBtn(formName), 'a')),
-    ])
+    await makeEditButtonsVisible({ nodeDefName: formName })
+
+    const editBtnSelector = getSelector(DataTestId.surveyForm.nodeDefEditBtn(formName), 'a')
+    await page.waitForSelector(editBtnSelector)
+
+    await Promise.all([page.waitForNavigation(), page.click(editBtnSelector)])
   })
 
   if (editDetails) editNodeDefDetails(nodeDef)

--- a/test/e2e/tests/_record/utils.js
+++ b/test/e2e/tests/_record/utils.js
@@ -6,7 +6,7 @@ export const parseValue = (value) => (typeof value === 'function' ? value() : va
 
 // ==== selector utils
 export const getNodeDefSelector = (nodeDef, parentSelector = '') =>
-  `${parentSelector} ${getSelector(nodeDef.name)}`.trim()
+  `${parentSelector} ${getSelector(DataTestId.surveyForm.nodeDefWrapper(nodeDef.name))}`.trim()
 
 export const getBooleanSelector = (nodeDef, parentSelector, value) =>
   `${getNodeDefSelector(nodeDef, parentSelector)} button[data-value="${value}"]`

--- a/test/e2e/tests/nodeDefReorder.js
+++ b/test/e2e/tests/nodeDefReorder.js
@@ -6,8 +6,8 @@ import { gotoFormPage } from './_formDesigner'
 import { publishWithoutErrors } from './_publish'
 
 const getBBoxes = async (nodeDefTarget, nodeDefSource) => {
-  const targetEl = await page.$(getSelector(nodeDefTarget.name))
-  const sourceEl = await page.$(getSelector(nodeDefSource.name))
+  const targetEl = await page.$(getSelector(DataTestId.surveyForm.nodeDefWrapper(nodeDefTarget.name)))
+  const sourceEl = await page.$(getSelector(DataTestId.surveyForm.nodeDefWrapper(nodeDefSource.name)))
   await targetEl.scrollIntoViewIfNeeded()
   const targetBBox = await targetEl.boundingBox()
   const sourceBBox = await sourceEl.boundingBox()
@@ -31,15 +31,17 @@ const moveBelow = async (nodeDefTarget, nodeDefSource) => {
   await dragAndDrop(targetBBox.x + 2, targetBBox.y + 2, sourceBBox.x, sourceBBox.y + sourceBBox.height + 5)
 }
 
-const moveEntityTableCell = (offset = { x: 2, y: 2 }) => async (nodeDefTarget, nodeDefSource) => {
-  const { targetEl, sourceEl, targetBBox, sourceBBox } = await getBBoxes(nodeDefTarget, nodeDefSource)
-  await dragAndDropOver({
-    targetEl,
-    sourceEl,
-    from: { x: targetBBox.x + 2, y: targetBBox.y + 2 },
-    to: { x: getBoxCenter(sourceBBox).x + offset.x, y: sourceBBox.y + offset.y },
-  })
-}
+const moveEntityTableCell =
+  (offset = { x: 2, y: 2 }) =>
+  async (nodeDefTarget, nodeDefSource) => {
+    const { targetEl, sourceEl, targetBBox, sourceBBox } = await getBBoxes(nodeDefTarget, nodeDefSource)
+    await dragAndDropOver({
+      targetEl,
+      sourceEl,
+      from: { x: targetBBox.x + 2, y: targetBBox.y + 2 },
+      to: { x: getBoxCenter(sourceBBox).x + offset.x, y: sourceBBox.y + offset.y },
+    })
+  }
 const moveEntityTableCellRight = moveEntityTableCell({ x: 5, y: 2 })
 const moveEntityTableCellLeft = moveEntityTableCell({ x: -5, y: 2 })
 

--- a/test/e2e/tests/surveyFormPreview.js
+++ b/test/e2e/tests/surveyFormPreview.js
@@ -65,7 +65,7 @@ export default () =>
       gotoFormPage(plot)
 
       test(`Verify ${plot.name} not required and not applicable`, async () => {
-        const plotEl = await page.$(getSelector(plot.name))
+        const plotEl = await page.$(getSelector(DataTestId.surveyForm.nodeDefWrapper(plot.name)))
         await expect(await plotEl.getAttribute('class')).toContain('not-applicable')
 
         await page.hover(`text="${plot_id.label}"`)
@@ -87,7 +87,7 @@ export default () =>
     gotoFormPage(plot)
 
     test(`Verify ${plot.name} required and applicable`, async () => {
-      const plotEl = await page.$(getSelector(plot.name))
+      const plotEl = await page.$(getSelector(DataTestId.surveyForm.nodeDefWrapper(plot.name)))
       await expect(await plotEl.getAttribute('class')).not.toContain('not-applicable')
 
       await page.hover(`text="${plot_id.label}"`)

--- a/webapp/components/form/LabelWithTooltip/LabelWithTooltip.js
+++ b/webapp/components/form/LabelWithTooltip/LabelWithTooltip.js
@@ -1,0 +1,37 @@
+import React, { useEffect, useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+export const LabelWithTooltip = (props) => {
+  const { label, style, children } = props
+
+  const labelRef = useRef(null)
+
+  // detect when ellipsis is active and show a tooltip in that case
+  const [ellipsed, setEllipsed] = useState(false)
+  const tooltip = ellipsed ? label : null
+
+  useEffect(() => {
+    const labelEl = labelRef?.current
+    if (labelEl) {
+      setEllipsed(labelEl.offsetHeight < labelEl.scrollHeight || labelEl.offsetWidth < labelEl.scrollWidth)
+    }
+  }, [label])
+
+  return (
+    <div className="label ellipsis" style={style} title={tooltip} ref={labelRef}>
+      {children}
+      {label}
+    </div>
+  )
+}
+
+LabelWithTooltip.propTypes = {
+  label: PropTypes.string.isRequired,
+  style: PropTypes.object,
+  children: PropTypes.node,
+}
+
+LabelWithTooltip.defaultProps = {
+  style: {},
+  children: null,
+}

--- a/webapp/components/form/LabelWithTooltip/index.js
+++ b/webapp/components/form/LabelWithTooltip/index.js
@@ -1,0 +1,1 @@
+export { LabelWithTooltip } from './LabelWithTooltip'

--- a/webapp/components/survey/NodeDefDetails/AnalysisCodeProps/index.js
+++ b/webapp/components/survey/NodeDefDetails/AnalysisCodeProps/index.js
@@ -30,18 +30,22 @@ const AnalysisCodeProps = (props) => {
     const langTools = ace.require('ace/ext/language_tools')
 
     // data stub:
-    const otherNodeDefs = Survey.getNodeDefsArray(survey).map((_nodeDef) => ({
-      name: NodeDef.getName(_nodeDef),
-      description: NodeDef.getLabel(_nodeDef),
-    }))
+    const otherNodeDefs = Survey.getNodeDefsArray(survey).map((_nodeDef) => {
+      const parent = Survey.getNodeDefByUuid(NodeDef.getParentUuid(_nodeDef))(survey)
+      return {
+        name: NodeDef.getName(_nodeDef),
+        description: NodeDef.getLabel(_nodeDef),
+        parent,
+      }
+    })
 
     const sqlTablesCompleter = {
       getCompletions: (editor, session, pos, prefix, callback) => {
         callback(
           null,
-          otherNodeDefs.map((table) => ({
-            caption: `${table.name}: ${table.description}`,
-            value: table.name,
+          otherNodeDefs.map((_nodeDef) => ({
+            caption: `${_nodeDef.name}: ${_nodeDef.description}`,
+            value: `${NodeDef.getName(_nodeDef.parent)}$${_nodeDef.name}`,
             meta: 'Table',
           }))
         )

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefEditButtons.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefEditButtons.js
@@ -103,8 +103,6 @@ const NodeDefEditButtons = (props) => {
 NodeDefEditButtons.propTypes = {
   surveyCycleKey: PropTypes.string.isRequired,
   nodeDef: PropTypes.object.isRequired,
-  edit: PropTypes.bool.isRequired,
-  canEditDef: PropTypes.bool.isRequired,
 }
 
 export default NodeDefEditButtons

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefEditButtons.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefEditButtons.js
@@ -16,11 +16,10 @@ import { SurveyFormActions, SurveyFormState } from '@webapp/store/ui/surveyForm'
 import { DataTestId } from '@webapp/utils/dataTestId'
 
 const NodeDefEditButtons = (props) => {
-  const { surveyCycleKey, nodeDef, edit, canEditDef } = props
+  const { surveyCycleKey, nodeDef } = props
 
   const dispatch = useDispatch()
 
-  const show = edit && canEditDef
   const elementRef = useRef(null)
   const [style, setStyle] = useState({})
 
@@ -29,79 +28,75 @@ const NodeDefEditButtons = (props) => {
   const hasNodeDefAddChildTo = Boolean(useSelector(SurveyFormState.getNodeDefAddChildTo))
 
   useEffect(() => {
-    if (show) {
-      const { parentNode } = elementRef.current
-      if (parentNode.classList.contains('survey-form__node-def-page')) {
-        const right = hasNodeDefAddChildTo ? 225 : 25
-        const { top } = elementOffset(parentNode)
-        setStyle({ position: 'fixed', top: `${top}px`, right: `${right}px` })
-      }
+    const { parentNode } = elementRef.current
+    if (parentNode.classList.contains('survey-form__node-def-page')) {
+      const right = hasNodeDefAddChildTo ? 225 : 25
+      const { top } = elementOffset(parentNode)
+      setStyle({ position: 'fixed', top: `${top}px`, right: `${right}px` })
     }
-  }, [show, hasNodeDefAddChildTo])
+  }, [hasNodeDefAddChildTo])
 
   return (
-    show && (
-      <div className="survey-form__node-def-edit-buttons" ref={elementRef} style={style}>
-        {NodeDefLayout.hasPage(surveyCycleKey)(nodeDef) && (
-          <div className="survey-form__node-def-edit-page-props">
-            {i18n.t('surveyForm.nodeDefEditFormActions.columns')}
-            <input
-              value={NodeDefLayout.getColumnsNo(surveyCycleKey)(nodeDef)}
-              type="number"
-              min="1"
-              max="12"
-              step="1"
-              onChange={(event) => {
-                const value = Number(event.target.value)
-                if (value > 0)
-                  dispatch(
-                    NodeDefsActions.putNodeDefLayoutProp({
-                      nodeDef,
-                      key: NodeDefLayout.keys.columnsNo,
-                      value,
-                    })
-                  )
-              }}
-            />
-          </div>
-        )}
+    <div className="survey-form__node-def-edit-buttons" ref={elementRef} style={style}>
+      {NodeDefLayout.hasPage(surveyCycleKey)(nodeDef) && (
+        <div className="survey-form__node-def-edit-page-props">
+          {i18n.t('surveyForm.nodeDefEditFormActions.columns')}
+          <input
+            value={NodeDefLayout.getColumnsNo(surveyCycleKey)(nodeDef)}
+            type="number"
+            min="1"
+            max="12"
+            step="1"
+            onChange={(event) => {
+              const value = Number(event.target.value)
+              if (value > 0)
+                dispatch(
+                  NodeDefsActions.putNodeDefLayoutProp({
+                    nodeDef,
+                    key: NodeDefLayout.keys.columnsNo,
+                    value,
+                  })
+                )
+            }}
+          />
+        </div>
+      )}
 
-        <Link
-          data-testid={DataTestId.surveyForm.nodeDefEditBtn(NodeDef.getName(nodeDef))}
-          className="btn btn-s btn-transparent survey-form__node-def-edit-button"
-          to={`${appModuleUri(designerModules.nodeDef)}${NodeDef.getUuid(nodeDef)}/`}
+      <Link
+        data-testid={DataTestId.surveyForm.nodeDefEditBtn(NodeDef.getName(nodeDef))}
+        className="btn btn-s btn-transparent survey-form__node-def-edit-button"
+        to={`${appModuleUri(designerModules.nodeDef)}${NodeDef.getUuid(nodeDef)}/`}
+      >
+        <span className="icon icon-pencil2 icon-12px" />
+      </Link>
+
+      {NodeDef.isEntity(nodeDef) && (
+        <button
+          type="button"
+          data-testid={DataTestId.surveyForm.nodeDefAddChildBtn(NodeDef.getName(nodeDef))}
+          className="btn btn-s btn-transparent"
+          onClick={() => dispatch(SurveyFormActions.setFormNodeDefAddChildTo(nodeDef))}
+          onMouseDown={(e) => {
+            e.stopPropagation()
+          }}
         >
-          <span className="icon icon-pencil2 icon-12px" />
-        </Link>
+          <span className="icon icon-plus icon-12px" />
+        </button>
+      )}
 
-        {NodeDef.isEntity(nodeDef) && (
-          <button
-            type="button"
-            data-testid={DataTestId.surveyForm.nodeDefAddChildBtn(NodeDef.getName(nodeDef))}
-            className="btn btn-s btn-transparent"
-            onClick={() => dispatch(SurveyFormActions.setFormNodeDefAddChildTo(nodeDef))}
-            onMouseDown={(e) => {
-              e.stopPropagation()
-            }}
-          >
-            <span className="icon icon-plus icon-12px" />
-          </button>
-        )}
-
-        {!NodeDef.isRoot(nodeDef) && (
-          <button
-            type="button"
-            className="btn btn-s btn-transparent"
-            onClick={() => dispatch(NodeDefsActions.removeNodeDef(nodeDef))}
-            onMouseDown={(e) => {
-              e.stopPropagation()
-            }}
-          >
-            <span className="icon icon-bin2 icon-12px" />
-          </button>
-        )}
-      </div>
-    )
+      {!NodeDef.isRoot(nodeDef) && (
+        <button
+          type="button"
+          className="btn btn-s btn-transparent"
+          onClick={() => dispatch(NodeDefsActions.removeNodeDef(nodeDef))}
+          onMouseDown={(e) => {
+            e.stopPropagation()
+          }}
+        >
+          <span className="icon icon-bin2 icon-12px" />
+        </button>
+      )}
+    </div>
   )
 }
 

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.js
@@ -1,49 +1,15 @@
 import './nodeDefTableCellHeader.scss'
 
-import React, { useEffect, useRef, useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import * as NodeDef from '@core/survey/nodeDef'
 
+import { LabelWithTooltip } from '@webapp/components/form/LabelWithTooltip'
 import { useI18n } from '@webapp/store/system'
 
 import * as NodeDefUiProps from '../nodeDefUIProps'
 import NodeDefIconKey from './NodeDefIconKey'
-
-const LabelWithTooltip = (props) => {
-  const { label, style, children } = props
-
-  const labelRef = useRef(null)
-
-  // detect when ellipsis is active and show a tooltip in that case
-  const [ellipsed, setEllipsed] = useState(false)
-  const tooltip = ellipsed ? label : null
-
-  useEffect(() => {
-    const labelEl = labelRef?.current
-    if (labelEl) {
-      setEllipsed(labelEl.offsetHeight < labelEl.scrollHeight || labelEl.offsetWidth < labelEl.scrollWidth)
-    }
-  }, [label])
-
-  return (
-    <div className="label ellipsis" style={style} title={tooltip} ref={labelRef}>
-      {children}
-      {label}
-    </div>
-  )
-}
-
-LabelWithTooltip.propTypes = {
-  label: PropTypes.string.isRequired,
-  style: PropTypes.object,
-  children: PropTypes.node,
-}
-
-LabelWithTooltip.defaultProps = {
-  style: {},
-  children: null,
-}
 
 const NodeDefTableCellHeader = (props) => {
   const { label, nodeDef } = props

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.js
@@ -34,6 +34,17 @@ const LabelWithTooltip = (props) => {
   )
 }
 
+LabelWithTooltip.propTypes = {
+  label: PropTypes.string.isRequired,
+  style: PropTypes.object,
+  children: PropTypes.node,
+}
+
+LabelWithTooltip.defaultProps = {
+  style: {},
+  children: null,
+}
+
 const NodeDefTableCellHeader = (props) => {
   const { label, nodeDef } = props
 

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.js
@@ -1,6 +1,6 @@
 import './nodeDefTableCellHeader.scss'
 
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import * as NodeDef from '@core/survey/nodeDef'
@@ -10,21 +10,44 @@ import { useI18n } from '@webapp/store/system'
 import * as NodeDefUiProps from '../nodeDefUIProps'
 import NodeDefIconKey from './NodeDefIconKey'
 
+const LabelWithTooltip = (props) => {
+  const { label, style, children } = props
+
+  const labelRef = useRef(null)
+
+  // detect when ellipsis is active and show a tooltip in that case
+  const [ellipsed, setEllipsed] = useState(false)
+  const tooltip = ellipsed ? label : null
+
+  useEffect(() => {
+    const labelEl = labelRef?.current
+    if (labelEl) {
+      setEllipsed(labelEl.offsetHeight < labelEl.scrollHeight || labelEl.offsetWidth < labelEl.scrollWidth)
+    }
+  }, [label])
+
+  return (
+    <div className="label ellipsis" style={style} title={tooltip} ref={labelRef}>
+      {children}
+      {label}
+    </div>
+  )
+}
+
 const NodeDefTableCellHeader = (props) => {
   const { label, nodeDef } = props
 
-  const fields = NodeDefUiProps.getFormFields(nodeDef)
-
   const i18n = useI18n()
+
+  const fields = NodeDefUiProps.getFormFields(nodeDef)
 
   return (
     <div
       className={`survey-form__node-def-table-cell-header survey-form__node-def-table-cell-${NodeDef.getType(nodeDef)}`}
     >
-      <div className="label" style={{ gridColumn: `1 / span ${fields.length}` }}>
+      <LabelWithTooltip label={label} style={{ gridColumn: `1 / span ${fields.length}` }}>
         <NodeDefIconKey nodeDef={nodeDef} />
-        {label}
-      </div>
+      </LabelWithTooltip>
 
       {fields.length > 1 &&
         fields.map((field) => (

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.scss
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/nodeDefTableCellHeader.scss
@@ -1,12 +1,22 @@
 @import '~@webapp/style/vars';
 
+.survey-form__node-def-entity-table-row-header {
+  .react-grid-item {
+    .survey-form__node-def-page-item {
+      display: flex;
+    }
+  }
+}
+
 .survey-form__node-def-table-cell-header {
-  display: grid;
+  display: flex;
+  width: 100%;
   background-color: $black;
 
   .label {
-    justify-self: center;
+    width: 100%;
     align-self: center;
+    justify-self: center;
     font-weight: 600;
     font-size: 0.8rem;
     text-align: center;

--- a/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefEntityTable.scss
+++ b/webapp/components/survey/SurveyForm/nodeDefs/components/types/nodeDefEntityTable.scss
@@ -53,10 +53,6 @@
   background-color: rgba($blueLight, 0.3);
   border-right: 1px solid transparent;
 
-  .react-grid-item {
-    display: grid;
-  }
-
   &.drag-in-progress .draggable-item * {
     pointer-events: none;
 

--- a/webapp/components/survey/SurveyForm/nodeDefs/nodeDefSwitch.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/nodeDefSwitch.js
@@ -17,6 +17,7 @@ import { RecordActions, RecordState } from '@webapp/store/ui/record'
 import * as NodeDefUiProps from './nodeDefUIProps'
 
 import { SurveyFormState } from '@webapp/store/ui/surveyForm'
+import { DataTestId } from '@webapp/utils/dataTestId'
 
 // Edit actions
 // Entry actions
@@ -83,10 +84,11 @@ class NodeDefSwitch extends React.Component {
     return (
       <div
         className={className}
-        data-testid={NodeDef.getName(nodeDef)}
+        data-testid={DataTestId.surveyForm.nodeDefWrapper(NodeDef.getName(nodeDef))}
         ref={this.element}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
+        onMouseMove={this.onMouseEnter}
       >
         {editButtonsVisible && (
           <NodeDefEditButtons surveyCycleKey={surveyCycleKey} nodeDef={nodeDef} edit={edit} canEditDef={canEditDef} />

--- a/webapp/components/survey/SurveyForm/nodeDefs/nodeDefSwitch.js
+++ b/webapp/components/survey/SurveyForm/nodeDefs/nodeDefSwitch.js
@@ -30,6 +30,13 @@ class NodeDefSwitch extends React.Component {
     super(props)
 
     this.element = React.createRef()
+
+    this.state = {
+      isHovering: false,
+    }
+
+    this.onMouseEnter = this.onMouseEnter.bind(this)
+    this.onMouseLeave = this.onMouseLeave.bind(this)
   }
 
   checkNodePlaceholder() {
@@ -54,8 +61,19 @@ class NodeDefSwitch extends React.Component {
     this.checkNodePlaceholder()
   }
 
+  onMouseEnter() {
+    this.setState({ isHovering: true })
+  }
+
+  onMouseLeave() {
+    this.setState({ isHovering: false })
+  }
+
   render() {
     const { surveyCycleKey, nodeDef, label, edit, canEditDef, renderType, applicable } = this.props
+    const { isHovering } = this.state
+
+    const editButtonsVisible = edit && canEditDef && isHovering
 
     const className =
       'survey-form__node-def-page' +
@@ -63,9 +81,16 @@ class NodeDefSwitch extends React.Component {
       (applicable ? '' : ' not-applicable')
 
     return (
-      <div className={className} data-testid={NodeDef.getName(nodeDef)} ref={this.element}>
-        <NodeDefEditButtons surveyCycleKey={surveyCycleKey} nodeDef={nodeDef} edit={edit} canEditDef={canEditDef} />
-
+      <div
+        className={className}
+        data-testid={NodeDef.getName(nodeDef)}
+        ref={this.element}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
+        {editButtonsVisible && (
+          <NodeDefEditButtons surveyCycleKey={surveyCycleKey} nodeDef={nodeDef} edit={edit} canEditDef={canEditDef} />
+        )}
         {renderType === NodeDefLayout.renderType.tableHeader ? (
           <NodeDefTableCellHeader nodeDef={nodeDef} label={label} />
         ) : renderType === NodeDefLayout.renderType.tableBody ? (

--- a/webapp/utils/dataTestId/index.js
+++ b/webapp/utils/dataTestId/index.js
@@ -137,6 +137,7 @@ export const DataTestId = {
     nodeDefAddChildBtn: (name) => `${name}-add-child-btn`,
     nodeDefEditBtn: (name) => `${name}-edit-btn`,
     nodeDefErrorBadge: (name) => `${name}-error-badge`,
+    nodeDefWrapper: (name) => `node-def-wrapper-${name}`,
     pageLinkBtn: (name) => `${name}-page-link-btn`,
     previewCloseBtn: 'preview-close-btn',
     previewOpenBtn: 'preview-open-btn',


### PR DESCRIPTION
In node def table header, show the node def edit buttons only on mouse over and show a tooltip with the full label/name if the text is too long and overflows the width of the column.
Necessary because when node def names are long it is quite difficult to find a node definition.