### PR TITLE
fixed error in generated expression using basic expression editor wit…

### DIFF
--- a/webapp/components/expression/nodes/literal.js
+++ b/webapp/components/expression/nodes/literal.js
@@ -24,14 +24,7 @@ import * as ExpressionParser from '../expressionParser'
 import { BinaryOperandType } from './binaryOperand'
 
 const isValueText = (nodeDef, value) =>
-  nodeDef
-    ? !(
-        NodeDef.isInteger(nodeDef) ||
-        NodeDef.isCode(nodeDef) ||
-        NodeDef.isDecimal(nodeDef) ||
-        StringUtils.isBlank(value)
-      )
-    : false
+  nodeDef ? !(NodeDef.isInteger(nodeDef) || NodeDef.isDecimal(nodeDef) || StringUtils.isBlank(value)) : false
 
 const parseValue = (nodeDef, value) => (isValueText(nodeDef, value) ? A.parse(value) : value)
 


### PR DESCRIPTION
when using a code attribute as right operand in a binary expression and the category has numeric values as codes, the generated expression is wrong. 
e.g. `cluster_accessibility == 99` while it should be `cluster_accessibility == '99'`, so the value must be "stringified".