### PR TITLE
Survey publish speed

### DIFF
--- a/core/record/_record/recordNodesIndex.js
+++ b/core/record/_record/recordNodesIndex.js
@@ -116,10 +116,8 @@ const _addNode =
 export const addNewNodes = (nodes) => (record) => {
   let recordUpdated = { ...record }
   Object.values(nodes).forEach((node) => {
-    if (!Node.isDeleted(node)) {
-      // nodes should not be already in the cache, do not check for duplicates.
-      recordUpdated = _addNode({ node, avoidDuplicates: false })(recordUpdated)
-    }
+    // nodes should not be already in the cache, do not check for duplicates.
+    recordUpdated = _addNode({ node, avoidDuplicates: false })(recordUpdated)
   })
   return recordUpdated
 }
@@ -129,15 +127,14 @@ export const addOrUpdateNode = (node) => _addNode({ node, avoidDuplicates: true 
 const _addNodeToCodeDependentsIndex =
   ({ node, avoidDuplicates = true }) =>
   (record) =>
-    R.reduce(
+    Node.getHierarchyCode(node).reduce(
       (recordAcc, ancestorCodeAttributeUuid) =>
         _assocToIndexPath({
           path: [keys.nodeCodeDependents, ancestorCodeAttributeUuid],
           value: Node.getUuid(node),
           avoidDuplicates,
         })(recordAcc),
-      record,
-      Node.getHierarchyCode(node)
+      record
     )
 
 // ===== DELETE

--- a/core/survey/nodeDef.js
+++ b/core/survey/nodeDef.js
@@ -35,6 +35,9 @@ export const keys = {
   propsAdvancedDraft: 'propsAdvancedDraft',
   meta: 'meta',
   draftAdvanced: 'draftAdvanced',
+  draftAdvancedApplicable: 'draftAdvancedApplicable',
+  draftAdvancedDefaultValues: 'draftAdvancedDefaultValues',
+  draftAdvancedValidations: 'draftAdvancedValidations',
   type: 'type',
   deleted: 'deleted',
   analysis: 'analysis',
@@ -251,6 +254,9 @@ export const getPropOrDraftAdvanced =
     getPropAdvancedDraft(prop, getPropAdvanced(prop, defaultTo)(nodeDef))(nodeDef)
 
 export const hasAdvancedPropsDraft = (nodeDef) => R.prop(keys.draftAdvanced, nodeDef) === true
+export const hasAdvancedPropsApplicableDraft = (nodeDef) => R.prop(keys.draftAdvancedApplicable, nodeDef) === true
+export const hasAdvancedPropsDefaultValuesDraft = (nodeDef) => R.prop(keys.draftAdvancedDefaultValues, nodeDef) === true
+export const hasAdvancedPropsValidationsDraft = (nodeDef) => R.prop(keys.draftAdvancedValidations, nodeDef) === true
 const isPropAdvanced = (key) => Object.keys(keysPropsAdvanced).includes(key)
 
 export const getDefaultValues = getPropAdvanced(keysPropsAdvanced.defaultValues, [])
@@ -284,7 +290,8 @@ export const isReadOnlyOrAnalysis = (nodeDef) => isReadOnly(nodeDef) || isAnalys
 export const isBaseUnit = (nodeDef) => Boolean(getPropOrDraftAdvanced(keysPropsAdvanced.isBaseUnit, false)(nodeDef))
 export const isSampling = (nodeDef) => Boolean(getPropOrDraftAdvanced(keysPropsAdvanced.isSampling, false)(nodeDef))
 export const getAreaBasedEstimatedOf = getPropOrDraftAdvanced(keysPropsAdvanced.areaBasedEstimatedOf, false)
-export const isAreaBasedEstimatedOf = nodeDef => Boolean(getPropOrDraftAdvanced(keysPropsAdvanced.areaBasedEstimatedOf, false)(nodeDef))
+export const isAreaBasedEstimatedOf = (nodeDef) =>
+  Boolean(getPropOrDraftAdvanced(keysPropsAdvanced.areaBasedEstimatedOf, false)(nodeDef))
 
 // ==== CREATE
 

--- a/server/modules/nodeDef/repository/nodeDefRepository.js
+++ b/server/modules/nodeDef/repository/nodeDefRepository.js
@@ -16,6 +16,18 @@ const dbTransformCallback = ({ row, draft, advanced = false, backup = false }) =
     if (!R.isEmpty(rowUpdated.props_advanced_draft)) {
       // there are draft advanced props to merge with "published" advanced props
       rowUpdated.draft_advanced = true
+
+      // set updated props flags
+      if (rowUpdated.props_advanced_draft[NodeDef.keysPropsAdvanced.validations]) {
+        rowUpdated.draft_advanced_validations = true
+      }
+      if (rowUpdated.props_advanced_draft[NodeDef.keysPropsAdvanced.applicable]) {
+        rowUpdated.draft_advanced_applicable = true
+      }
+      if (rowUpdated.props_advanced_draft[NodeDef.keysPropsAdvanced.defaultValues]) {
+        rowUpdated.draft_advanced_default_values = true
+      }
+
       if (draft && !backup) {
         // merge props_advanced and props_advanced_draft into props_advanced
         rowUpdated.props_advanced = R.mergeDeepLeft(row.props_advanced_draft, row.props_advanced)
@@ -213,7 +225,7 @@ export const updateNodeDefPropsInBatch = async ({ surveyId, nodeDefs }, client =
           [nodeDefUuid, props, propsAdvanced],
           (row) => dbTransformCallback({ row, draft: true, advanced: true }) // Always loading draft when updating a nodeDef
         )
-      }),
+      })
     )
     return nodedefsUpdated
   })

--- a/server/modules/record/manager/recordManager.js
+++ b/server/modules/record/manager/recordManager.js
@@ -111,7 +111,8 @@ export const fetchRecordAndNodesByUuid = async (
     client
   )
 
-  return Record.assocNodes({ nodes: ObjectUtils.toUuidIndexedObj(nodes), updateNodesIndex: fetchForUpdate })(record)
+  const indexedNodes = ObjectUtils.toUuidIndexedObj(nodes)
+  return Record.assocNodes({ nodes: indexedNodes, updateNodesIndex: fetchForUpdate })(record)
 }
 
 export { fetchNodeByUuid, fetchChildNodesByNodeDefUuids, insertNodesInBatch } from '../repository/nodeRepository'

--- a/server/modules/record/repository/nodeRepository.js
+++ b/server/modules/record/repository/nodeRepository.js
@@ -114,7 +114,6 @@ export const insertNode = async (surveyId, node, draft, client = db) => {
   // reload node to get node ref data
   const nodeAdded = await fetchNodeWithRefDataByUuid({ surveyId, nodeUuid: Node.getUuid(node), draft }, client)
 
-  console.log('---nodeAdded', nodeAdded)
   return { ...nodeAdded, [Node.keys.created]: true }
 }
 

--- a/server/modules/record/repository/nodeRepository.js
+++ b/server/modules/record/repository/nodeRepository.js
@@ -46,8 +46,12 @@ const _toValueQueryParam = (value) => (value === null || A.isEmpty(value) ? null
 const _getNodeSelectQuery = ({ surveyId, includeRefData = true, draft = true, excludeRecordUuid = false }) => {
   const schema = getSurveyDBSchema(surveyId)
 
+  const selectFields = (excludeRecordUuid ? R.without(['record_uuid'], tableColumnsSelect) : tableColumnsSelect)
+    .map((field) => `n.${field}`)
+    .join(', ')
+
   if (!includeRefData) {
-    return `SELECT n.* FROM ${schema}.node n`
+    return `SELECT ${selectFields} FROM ${schema}.node n`
   }
 
   // include ref data (category items, taxa, etc.)
@@ -55,10 +59,6 @@ const _getNodeSelectQuery = ({ surveyId, includeRefData = true, draft = true, ex
   const propsTaxon = DbUtils.getPropsCombined(draft, 't.', false)
   const propsVernacularName = DbUtils.getPropsCombined(draft, 'v.', false)
   const propsCategoryItem = DbUtils.getPropsCombined(draft, 'c.', false)
-
-  const selectFields = (excludeRecordUuid ? R.without('record_uuid', tableColumnsSelect) : tableColumnsSelect)
-    .map((field) => `n.${field}`)
-    .join(', ')
 
   return `
     SELECT

--- a/server/modules/survey/service/recordCheckJob.js
+++ b/server/modules/survey/service/recordCheckJob.js
@@ -68,8 +68,13 @@ export default class RecordCheckJob extends Job {
         } else if (!NodeDef.isPublished(def)) {
           // New node def
           nodeDefAddedUuids.push(nodeDefUuid)
-        } else if (NodeDef.hasAdvancedPropsDraft(def)) {
-          // Already existing node def but validations have been updated
+        } else if (
+          NodeDef.hasAdvancedPropsDraft(def) &&
+          (NodeDef.hasAdvancedPropsApplicableDraft(def) ||
+            NodeDef.hasAdvancedPropsDefaultValuesDraft(def) ||
+            NodeDef.hasAdvancedPropsValidationsDraft(def))
+        ) {
+          // Already existing node def but applicable or default values or validations have been updated
           nodeDefUpdatedUuids.push(nodeDefUuid)
         }
       })


### PR DESCRIPTION
Improved survey publish speed (RecordCheckJob) by checking records only if node defs default values, applicability or default values have been changed.
Fetch nodes excluding record_uuid improves the speed significantly. This can be done when fetching nodes by record uuid (record uuid is already known and can be associated to the fetched rows after the fetch completes).