### PR TITLE
Fixed bug: running RStudio code locally fails if Files tab is not active

### DIFF
--- a/webapp/store/ui/chain/actions/openRStudio.js
+++ b/webapp/store/ui/chain/actions/openRStudio.js
@@ -54,6 +54,7 @@ const _getRStudioCode = ({
   unzip("${zipFile}", exdir="${isLocal ? localDir : '.'}");\r\n
   file.remove("${zipFile}");\r\n
   ${isLocal ? `setwd('${localDir}');` : ''}\r\n
+  ${isLocal ? `rstudioapi::executeCommand('activateFiles');` : ''}\r\n
   ${isLocal ? `rstudioapi::filesPaneNavigate(getwd());` : ''}\r\n
   rstudioapi::navigateToFile("arena.R")\r\n
   `


### PR DESCRIPTION
fixes #2197 