### PR TITLE
[FIX] fix exportFile to work with windows machines too

### DIFF
--- a/server/modules/survey/service/surveyExport/exportFile.js
+++ b/server/modules/survey/service/surveyExport/exportFile.js
@@ -1,5 +1,4 @@
-import * as FileUtils from '../../../../utils/file/fileUtils'
-
+const separator = '/'
 const dir = {
   activityLog: 'activitylog',
   categories: 'categories',
@@ -8,27 +7,27 @@ const dir = {
   records: 'records',
   taxonomies: 'taxonomies',
   users: 'users',
-  userProfilePictures: FileUtils.join('users', 'profilepictures'),
+  userProfilePictures: ['users', 'profilepictures'].join(separator),
 }
 
 export const ExportFile = {
-  activityLog: ({ index }) => FileUtils.join(dir.activityLog, `activityLog_${index}.json`),
-  categories: FileUtils.join(dir.categories, 'categories.json'),
-  categoryItems: ({ categoryUuid }) => FileUtils.join(dir.categories, `${categoryUuid}.json`),
-  chains: FileUtils.join(dir.chains, 'chains.json'),
-  chain: ({ chainUuid }) => FileUtils.join(dir.chains, `${chainUuid}.json`),
+  activityLog: ({ index }) => [dir.activityLog, `activityLog_${index}.json`].join(separator),
+  categories: [dir.categories, 'categories.json'].join(separator),
+  categoryItems: ({ categoryUuid }) => [dir.categories, `${categoryUuid}.json`].join(separator),
+  chains: [dir.chains, 'chains.json'].join(separator),
+  chain: ({ chainUuid }) => [dir.chains, `${chainUuid}.json`].join(separator),
   filesDir: dir.files,
-  filesSummaries: FileUtils.join(dir.files, 'files.json'),
-  file: ({ fileUuid }) => FileUtils.join(dir.files, `${fileUuid}.bin`),
-  records: FileUtils.join(dir.records, 'records.json'),
-  record: ({ recordUuid }) => FileUtils.join(dir.records, `${recordUuid}.json`),
+  filesSummaries: [dir.files, 'files.json'].join(separator),
+  file: ({ fileUuid }) => [dir.files, `${fileUuid}.bin`].join(separator),
+  records: [dir.records, 'records.json'].join(separator),
+  record: ({ recordUuid }) => [dir.records, `${recordUuid}.json`].join(separator),
   survey: 'survey.json',
-  taxonomies: FileUtils.join(dir.taxonomies, 'taxonomies.json'),
-  taxa: ({ taxonomyUuid }) => FileUtils.join(dir.taxonomies, `${taxonomyUuid}.json`),
-  users: FileUtils.join(dir.users, 'users.json'),
-  userInvitations: FileUtils.join(dir.users, 'userInvitations.json'),
-  userProfilePicture: ({ userUuid }) => FileUtils.join(dir.userProfilePictures, userUuid),
+  taxonomies: [dir.taxonomies, 'taxonomies.json'].join(separator),
+  taxa: ({ taxonomyUuid }) => [dir.taxonomies, `${taxonomyUuid}.json`].join(separator),
+  users: [dir.users, 'users.json'].join(separator),
+  userInvitations: [dir.users, 'userInvitations.json'].join(separator),
+  userProfilePicture: ({ userUuid }) => [dir.userProfilePictures, userUuid].join(separator),
 
   // Deprecated (old export format)
-  fileOld: ({ fileUuid }) => FileUtils.join(dir.files, `${fileUuid}.json`),
+  fileOld: ({ fileUuid }) => [dir.files, `${fileUuid}.json`].join(separator),
 }


### PR DESCRIPTION
## Description

<!--- List the changes proposed and/or how the issue(s) has(have) been solved. -->
Use constant separator in exportFile so you can read zips on windows that are made in UNIX machine.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How has this been tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually by importing a backup survey zip
Windows 11 Pro
Google Chrome 101.0.4951.67 64bit
#### Do you consider this PR needs further testing?

- [x] No
- [ ] Yes

<!--- If Yes, describe why or what to do next -->

## UI changes

<!--- Provide screenshots of any changes in the UI -->

## Disclaimer

<!--- Provide a description about anything unusual. -->
