### PR TITLE
Explorer / aggregate mode: exclude key attributes from measures

### DIFF
--- a/webapp/components/survey/NodeDefsSelector/NodeDefsSelectorAggregate.js
+++ b/webapp/components/survey/NodeDefsSelector/NodeDefsSelectorAggregate.js
@@ -107,6 +107,7 @@ const NodeDefsSelectorAggregate = (props) => {
               onToggleAttribute={onToggleMeasure}
               lang={lang}
               filterTypes={[NodeDef.nodeDefType.decimal, NodeDef.nodeDefType.integer]}
+              filterFunction={(nodeDef) => !NodeDef.isKey(nodeDef)}
               nodeDefLabelType={nodeDefLabelType}
               nodeDefUuidEntity={nodeDefUuidEntity}
               nodeDefUuidsAttributes={[...measures.keys()]}


### PR DESCRIPTION
fixes #2283 