### PR TITLE
fix(home): polish Survey Info branding form UX

### DIFF
--- a/core/i18n/resources/en/homeView.js
+++ b/core/i18n/resources/en/homeView.js
@@ -81,6 +81,8 @@ export default {
       surveyLogo3: 'Survey logo 3',
       landingBackground: 'Landing background image',
       uploadLogo: 'Upload image',
+      logoFileFormatHint: 'PNG, JPEG, WebP or SVG (max {{maxMb}} MB)',
+      logoFileTooLarge: 'Logo image must be {{maxMb}} MB or smaller',
       preview: 'Preview',
       backgroundFileTooLarge: 'Background image must be {{maxMb}} MB or smaller',
       invalidPrimaryColor: 'Enter a valid #RRGGBB color or leave empty',

--- a/core/i18n/resources/es/homeView.js
+++ b/core/i18n/resources/es/homeView.js
@@ -79,6 +79,8 @@ export default {
       surveyLogo3: '$t(homeView:surveyInfo.branding.surveyLogo3)',
       landingBackground: '$t(homeView:surveyInfo.branding.landingBackground)',
       uploadLogo: 'Subir logo',
+      logoFileFormatHint: '$t(homeView:surveyInfo.branding.logoFileFormatHint)',
+      logoFileTooLarge: '$t(homeView:surveyInfo.branding.logoFileTooLarge)',
       preview: 'Vista previa',
       backgroundFileTooLarge: '$t(homeView:surveyInfo.branding.backgroundFileTooLarge)',
       invalidPrimaryColor: 'Introduzca un color #RRGGBB válido o déjelo vacío',

--- a/core/i18n/resources/fr/homeView.js
+++ b/core/i18n/resources/fr/homeView.js
@@ -81,6 +81,8 @@ export default {
       surveyLogo3: '$t(homeView:surveyInfo.branding.surveyLogo3)',
       landingBackground: '$t(homeView:surveyInfo.branding.landingBackground)',
       uploadLogo: 'Téléverser le logo',
+      logoFileFormatHint: '$t(homeView:surveyInfo.branding.logoFileFormatHint)',
+      logoFileTooLarge: '$t(homeView:surveyInfo.branding.logoFileTooLarge)',
       preview: 'Aperçu',
       backgroundFileTooLarge: '$t(homeView:surveyInfo.branding.backgroundFileTooLarge)',
       invalidPrimaryColor: 'Saisissez une couleur #RRGGBB valide ou laissez vide',

--- a/core/i18n/resources/mn/homeView.js
+++ b/core/i18n/resources/mn/homeView.js
@@ -92,6 +92,8 @@ export default {
       surveyLogo3: '$t(homeView:surveyInfo.branding.surveyLogo3)',
       landingBackground: '$t(homeView:surveyInfo.branding.landingBackground)',
       uploadLogo: 'Лого байршуулах',
+      logoFileFormatHint: '$t(homeView:surveyInfo.branding.logoFileFormatHint)',
+      logoFileTooLarge: '$t(homeView:surveyInfo.branding.logoFileTooLarge)',
       preview: 'Урьдчилан харах',
       backgroundFileTooLarge: '$t(homeView:surveyInfo.branding.backgroundFileTooLarge)',
       invalidPrimaryColor: 'Зөв #RRGGBB өнгө оруулна уу эсвэл хоосон үлдээнэ үү',

--- a/core/i18n/resources/pt/homeView.js
+++ b/core/i18n/resources/pt/homeView.js
@@ -80,6 +80,8 @@ export default {
       surveyLogo3: '$t(homeView:surveyInfo.branding.surveyLogo3)',
       landingBackground: '$t(homeView:surveyInfo.branding.landingBackground)',
       uploadLogo: 'Enviar logo',
+      logoFileFormatHint: '$t(homeView:surveyInfo.branding.logoFileFormatHint)',
+      logoFileTooLarge: '$t(homeView:surveyInfo.branding.logoFileTooLarge)',
       preview: 'Pré-visualização',
       backgroundFileTooLarge: '$t(homeView:surveyInfo.branding.backgroundFileTooLarge)',
       invalidPrimaryColor: 'Insira uma cor #RRGGBB válida ou deixe em branco',

--- a/core/i18n/resources/ru/homeView.js
+++ b/core/i18n/resources/ru/homeView.js
@@ -92,6 +92,8 @@ export default {
       surveyLogo3: '$t(homeView:surveyInfo.branding.surveyLogo3)',
       landingBackground: '$t(homeView:surveyInfo.branding.landingBackground)',
       uploadLogo: 'Загрузить логотип',
+      logoFileFormatHint: '$t(homeView:surveyInfo.branding.logoFileFormatHint)',
+      logoFileTooLarge: '$t(homeView:surveyInfo.branding.logoFileTooLarge)',
       preview: 'Предпросмотр',
       backgroundFileTooLarge: '$t(homeView:surveyInfo.branding.backgroundFileTooLarge)',
       invalidPrimaryColor: 'Введите допустимый цвет #RRGGBB или оставьте пустым',

--- a/core/survey/surveyBranding.ts
+++ b/core/survey/surveyBranding.ts
@@ -27,8 +27,11 @@ export type FontSizePreset = (typeof fontSizePreset)[keyof typeof fontSizePreset
 
 export const fontSizePresetValues = Object.freeze(Object.values(fontSizePreset)) as readonly FontSizePreset[]
 
+/** Maximum branding image upload size in bytes (5 MiB). */
+export const BRANDING_IMAGE_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
+
 /** Maximum landing background upload size in bytes (5 MiB). */
-export const LANDING_BACKGROUND_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
+export const LANDING_BACKGROUND_MAX_FILE_SIZE_BYTES = BRANDING_IMAGE_MAX_FILE_SIZE_BYTES
 
 const HEX_COLOR_REGEXP = /^#[0-9A-Fa-f]{6}$/
 

--- a/test/unit/tests/036surveyBranding.test.js
+++ b/test/unit/tests/036surveyBranding.test.js
@@ -132,4 +132,13 @@ describe('SurveyBranding', () => {
       ).toBe(true)
     })
   })
+
+  describe('BRANDING_IMAGE_MAX_FILE_SIZE_BYTES', () => {
+    it('matches landing background limit', () => {
+      expect(SurveyBranding.BRANDING_IMAGE_MAX_FILE_SIZE_BYTES).toBe(5 * 1024 * 1024)
+      expect(SurveyBranding.LANDING_BACKGROUND_MAX_FILE_SIZE_BYTES).toBe(
+        SurveyBranding.BRANDING_IMAGE_MAX_FILE_SIZE_BYTES
+      )
+    })
+  })
 })

--- a/webapp/components/ColorInput.js
+++ b/webapp/components/ColorInput.js
@@ -13,6 +13,7 @@ export const ColorInput = (props) => {
   return (
     <div className="color-input">
       <MuiColorInput
+        key={value || 'empty'}
         disabled={disabled}
         format="hex"
         isAlphaHidden

--- a/webapp/components/ColorInput.js
+++ b/webapp/components/ColorInput.js
@@ -13,7 +13,7 @@ export const ColorInput = (props) => {
   return (
     <div className="color-input">
       <MuiColorInput
-        key={value || 'empty'}
+        key={value ? 'filled' : 'empty'}
         disabled={disabled}
         format="hex"
         isAlphaHidden

--- a/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.scss
+++ b/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.scss
@@ -16,7 +16,7 @@
   &__settings-row {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.25rem;
+    gap: 1.5rem;
     width: 100%;
 
     > .form-item {
@@ -29,10 +29,20 @@
         text-align: start;
       }
     }
-  }
 
-  &__font-size-dropdown {
-    width: 8rem;
+    .color-input {
+      width: 100%;
+
+      .MuiColorInput-TextField {
+        flex: 1 1 auto;
+        min-width: 0;
+        width: auto;
+      }
+    }
+
+    .survey-info-branding-form__settings-control {
+      width: 100%;
+    }
   }
 
   &__field-error {

--- a/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.scss
+++ b/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.scss
@@ -13,6 +13,28 @@
     align-items: start;
   }
 
+  &__settings-row {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem;
+    width: 100%;
+
+    > .form-item {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto;
+      gap: 0.35rem;
+
+      .form-label {
+        justify-self: start;
+        text-align: start;
+      }
+    }
+  }
+
+  &__font-size-dropdown {
+    width: 8rem;
+  }
+
   &__field-error {
     display: block;
     margin-top: 0.35rem;
@@ -50,6 +72,13 @@
     gap: 0.25rem;
   }
 
+  &__file-hint {
+    margin: 0;
+    font-size: 0.85rem;
+    color: color.adjust($black, $lightness: 35%);
+    line-height: 1.4;
+  }
+
   &__upload {
     display: flex;
     align-items: center;
@@ -59,9 +88,17 @@
     display: none;
   }
 
+  &__image-preview-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
   &__image-preview {
     display: flex;
     align-items: center;
+    flex: 1 1 auto;
+    min-width: 0;
     min-height: 3.5rem;
     padding: 0.5rem;
     background: $greyAppBg;
@@ -161,9 +198,12 @@
 
 @media (max-width: 1100px) {
   .survey-info-branding-form {
-    &__logos {
+    &__settings-row {
       grid-template-columns: 1fr;
     }
 
+    &__logos {
+      grid-template-columns: 1fr;
+    }
   }
 }

--- a/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.tsx
+++ b/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.tsx
@@ -38,6 +38,7 @@ const LOGO_FILE_INPUT_ACCEPT = 'image/png,image/jpeg,image/webp,image/svg+xml,.p
 const BACKGROUND_FILE_INPUT_ACCEPT = 'image/png,image/jpeg,image/webp,.png,.jpg,.jpeg,.webp'
 
 const LANDING_BACKGROUND_MAX_SIZE_MB = SurveyBranding.LANDING_BACKGROUND_MAX_FILE_SIZE_BYTES / (1024 * 1024)
+const LOGO_MAX_SIZE_MB = SurveyBranding.BRANDING_IMAGE_MAX_FILE_SIZE_BYTES / (1024 * 1024)
 
 type BrandingImageKey = SurveyLogoKey | typeof brandingKeys.landingBackground
 
@@ -120,24 +121,28 @@ const BrandingImageSection = (props: BrandingImageSectionProps) => {
   const i18n = useI18n()
   const imageSrc = useBrandingLogoSrc({ surveyId, logo: image, localObjectUrl })
   const hasImage = Boolean(imageSrc || image?.[brandingKeys.fileUuid])
+  const showLogoFormatHint = previewVariant === 'logo'
 
   return (
     <fieldset
       className={`survey-info-branding-form__image-section survey-info-branding-form__image-section--${previewVariant}`}
     >
       <legend>{i18n.t(labelKey)}</legend>
-      {!readOnly && (
-        <div className="survey-info-branding-form__upload-actions">
-          <input
-            ref={inputRef}
-            accept={fileInputAccept}
-            className="survey-info-branding-form__file-input"
-            onChange={onFileChange}
-            type="file"
-          />
-          {hasImage && onRemove ? (
-            <ButtonIconDelete onClick={onRemove} />
-          ) : (
+      {!readOnly && !hasImage && (
+        <>
+          {showLogoFormatHint && (
+            <p className="survey-info-branding-form__file-hint">
+              {i18n.t('homeView:surveyInfo.branding.logoFileFormatHint', { maxMb: LOGO_MAX_SIZE_MB })}
+            </p>
+          )}
+          <div className="survey-info-branding-form__upload-actions">
+            <input
+              ref={inputRef}
+              accept={fileInputAccept}
+              className="survey-info-branding-form__file-input"
+              onChange={onFileChange}
+              type="file"
+            />
             <div className="survey-info-branding-form__upload">
               <Button
                 disabled={uploading}
@@ -146,14 +151,17 @@ const BrandingImageSection = (props: BrandingImageSectionProps) => {
                 size="small"
               />
             </div>
-          )}
-        </div>
+          </div>
+        </>
       )}
       {imageSrc && (
-        <div
-          className={`survey-info-branding-form__image-preview survey-info-branding-form__image-preview--${previewVariant}`}
-        >
-          <img alt="" src={imageSrc} />
+        <div className="survey-info-branding-form__image-preview-row">
+          <div
+            className={`survey-info-branding-form__image-preview survey-info-branding-form__image-preview--${previewVariant}`}
+          >
+            <img alt="" src={imageSrc} />
+          </div>
+          {!readOnly && onRemove && <ButtonIconDelete onClick={onRemove} />}
         </div>
       )}
     </fieldset>
@@ -373,6 +381,12 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
         params: { extension: FileUtils.getExtension(file) },
       }
     }
+    if (file.size > SurveyBranding.BRANDING_IMAGE_MAX_FILE_SIZE_BYTES) {
+      return {
+        key: 'homeView:surveyInfo.branding.logoFileTooLarge',
+        params: { maxMb: LOGO_MAX_SIZE_MB },
+      }
+    }
     return null
   }, [])
 
@@ -420,38 +434,42 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
 
   return (
     <div className="form survey-info-branding-form">
-      <FormItem label="homeView:surveyInfo.branding.primaryColor">
-        <ColorInput disabled={readOnly} onChange={onPrimaryColorChange} value={primaryColor || ''} />
-        {primaryColorValidation && (
-          <span className="survey-info-branding-form__field-error">
-            {i18n.t('homeView:surveyInfo.branding.invalidPrimaryColor')}
-          </span>
-        )}
-      </FormItem>
+      <div className="survey-info-branding-form__settings-row">
+        <FormItem label="homeView:surveyInfo.branding.primaryColor">
+          <ColorInput disabled={readOnly} onChange={onPrimaryColorChange} value={primaryColor || ''} />
+          {primaryColorValidation && (
+            <span className="survey-info-branding-form__field-error">
+              {i18n.t('homeView:surveyInfo.branding.invalidPrimaryColor')}
+            </span>
+          )}
+        </FormItem>
 
-      <FormItem label="homeView:surveyInfo.branding.titleFontSize">
-        <Dropdown
-          disabled={readOnly}
-          items={[...fontSizePresetOptions]}
-          itemLabel={(preset) => i18n.t(`homeView:surveyInfo.branding.fontSizePreset.${preset}`)}
-          itemValue={A.identity}
-          onChange={(value) => onFontSizePresetChange(brandingKeys.titleFontSize, value as FontSizePreset)}
-          readOnly={readOnly}
-          selection={titleFontSize}
-        />
-      </FormItem>
+        <FormItem label="homeView:surveyInfo.branding.titleFontSize">
+          <Dropdown
+            className="survey-info-branding-form__font-size-dropdown"
+            disabled={readOnly}
+            items={[...fontSizePresetOptions]}
+            itemLabel={(preset) => i18n.t(`homeView:surveyInfo.branding.fontSizePreset.${preset}`)}
+            itemValue={A.identity}
+            onChange={(value) => onFontSizePresetChange(brandingKeys.titleFontSize, value as FontSizePreset)}
+            readOnly={readOnly}
+            selection={titleFontSize}
+          />
+        </FormItem>
 
-      <FormItem label="homeView:surveyInfo.branding.descriptionFontSize">
-        <Dropdown
-          disabled={readOnly}
-          items={[...fontSizePresetOptions]}
-          itemLabel={(preset) => i18n.t(`homeView:surveyInfo.branding.fontSizePreset.${preset}`)}
-          itemValue={A.identity}
-          onChange={(value) => onFontSizePresetChange(brandingKeys.descriptionFontSize, value as FontSizePreset)}
-          readOnly={readOnly}
-          selection={descriptionFontSize}
-        />
-      </FormItem>
+        <FormItem label="homeView:surveyInfo.branding.descriptionFontSize">
+          <Dropdown
+            className="survey-info-branding-form__font-size-dropdown"
+            disabled={readOnly}
+            items={[...fontSizePresetOptions]}
+            itemLabel={(preset) => i18n.t(`homeView:surveyInfo.branding.fontSizePreset.${preset}`)}
+            itemValue={A.identity}
+            onChange={(value) => onFontSizePresetChange(brandingKeys.descriptionFontSize, value as FontSizePreset)}
+            readOnly={readOnly}
+            selection={descriptionFontSize}
+          />
+        </FormItem>
+      </div>
 
       <div className="survey-info-branding-form__logos">
         {LOGO_SLOTS.map(({ imageKey, labelKey, fileType }) => {
@@ -518,6 +536,7 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
               </p>
             ) : null}
             <Button
+              key={previewColor ?? 'default'}
               color="primary"
               label="common:appModules.records"
               sx={

--- a/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.tsx
+++ b/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.tsx
@@ -446,7 +446,7 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
 
         <FormItem label="homeView:surveyInfo.branding.titleFontSize">
           <Dropdown
-            className="survey-info-branding-form__font-size-dropdown"
+            className="survey-info-branding-form__settings-control"
             disabled={readOnly}
             items={[...fontSizePresetOptions]}
             itemLabel={(preset) => i18n.t(`homeView:surveyInfo.branding.fontSizePreset.${preset}`)}
@@ -459,7 +459,7 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
 
         <FormItem label="homeView:surveyInfo.branding.descriptionFontSize">
           <Dropdown
-            className="survey-info-branding-form__font-size-dropdown"
+            className="survey-info-branding-form__settings-control"
             disabled={readOnly}
             items={[...fontSizePresetOptions]}
             itemLabel={(preset) => i18n.t(`homeView:surveyInfo.branding.fontSizePreset.${preset}`)}

--- a/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.tsx
+++ b/webapp/views/App/views/Home/SurveyInfo/SurveyInfoBrandingForm.tsx
@@ -25,6 +25,7 @@ import * as API from '@webapp/service/api'
 import { useSurveyId, useSurveyPreferredLang } from '@webapp/store/survey'
 import { useI18n } from '@webapp/store/system'
 import { NotificationActions } from '@webapp/store/ui'
+import { defaultTokens } from '@webapp/theme/tokens'
 import { FileUtils } from '@webapp/utils/fileUtils'
 
 const { keys: brandingKeys, fontSizePreset } = SurveyBranding
@@ -39,6 +40,7 @@ const BACKGROUND_FILE_INPUT_ACCEPT = 'image/png,image/jpeg,image/webp,.png,.jpg,
 
 const LANDING_BACKGROUND_MAX_SIZE_MB = SurveyBranding.LANDING_BACKGROUND_MAX_FILE_SIZE_BYTES / (1024 * 1024)
 const LOGO_MAX_SIZE_MB = SurveyBranding.BRANDING_IMAGE_MAX_FILE_SIZE_BYTES / (1024 * 1024)
+const DEFAULT_PREVIEW_BUTTON_COLOR = defaultTokens.colors.blue
 
 type BrandingImageKey = SurveyLogoKey | typeof brandingKeys.landingBackground
 
@@ -243,6 +245,7 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
   })
 
   const previewColor = resolvePreviewColor(primaryColor)
+  const previewButtonColor = previewColor ?? DEFAULT_PREVIEW_BUTTON_COLOR
   const previewTitleStyle = { fontSize: SurveyBranding.getTitleFontSizeRem({ props: { branding } }) }
   const previewDescriptionStyle = {
     fontSize: SurveyBranding.getDescriptionFontSizeRem({ props: { branding } }),
@@ -536,17 +539,12 @@ export const SurveyInfoBrandingForm = (props: SurveyInfoBrandingFormProps) => {
               </p>
             ) : null}
             <Button
-              key={previewColor ?? 'default'}
               color="primary"
               label="common:appModules.records"
-              sx={
-                previewColor
-                  ? {
-                      backgroundColor: previewColor,
-                      '&:hover': { backgroundColor: previewColor },
-                    }
-                  : undefined
-              }
+              sx={{
+                backgroundColor: previewButtonColor,
+                '&:hover': { backgroundColor: previewButtonColor },
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fix primary color preview not resetting when cleared with the X button after save
- Place primary color, title font size, and description font size on a single row with narrower dropdowns
- Move logo delete button to the right of the image preview, vertically centered
- Add logo file format hints above the upload button
- Cap logo uploads at 5 MB (same limit as background images)

## Test plan
- [ ] Open Survey Info → Branding tab
- [ ] Change primary color and confirm preview updates immediately
- [ ] Save, clear primary color with X, and confirm preview resets without another save
- [ ] Verify color + font size fields appear on one row; dropdowns are compact
- [ ] Upload a logo and confirm delete button sits to the right of the preview image
- [ ] Confirm format hint appears above logo upload button
- [ ] Try uploading a logo larger than 5 MB and confirm validation error
- [ ] Run unit tests: `yarn jest dist/__tests__/bundle.unit.js -t "SurveyBranding" --watchman=false`